### PR TITLE
feat: Add transfer service template

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -74,6 +74,11 @@ catalog:
       rules:
         - allow: [Template]
 
+    - type: file
+      target: ./templates/scaffolder/terraform-storage-transfer/template.yaml
+      rules:
+        - allow: [Template]
+
   providers:
     github:
       # the provider ID can be any camelCase string

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/CODEOWNERS
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @${{ values.githubOrg }}/${{ values.owner }}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/dependabot.yml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/dependabot.yml
@@ -1,0 +1,27 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+  - package-ecosystem: terraform
+    directory: /dev
+    groups:
+      actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+  - package-ecosystem: terraform
+    directory: /prod
+    groups:
+      actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/pull_request_template.md
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Write Good Commit Messages
+
+[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)
+
+* Separate subject from body with a blank line
+* Limit the subject line to 50 characters
+* Capitalize the subject line
+* Do not end the subject line with a period
+* Use the imperative mood in the subject line
+* Wrap the body at 72 characters
+* Use the body to explain what and why vs. how

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/workflows/checks.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.github/workflows/checks.yaml
@@ -1,0 +1,15 @@
+---
+name: checks
+
+"on":
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validation:
+    uses: broadinstitute/shared-workflows/.github/workflows/terraform-validate.yaml@v2.1.1
+  linting:
+    uses: broadinstitute/shared-workflows/.github/workflows/terraform-lint.yaml@v2.1.1
+    with:
+      tflint_config_path: .tflint.hcl

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.gitignore
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.auto.tfvars
+*.auto.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+.env

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/.tflint.hcl
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/.tflint.hcl
@@ -1,0 +1,39 @@
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+rule "terraform_documented_variables" {
+  enabled = true
+}
+rule "terraform_module_pinned_source" {
+  enabled = true
+}
+rule "terraform_naming_convention" {
+  enabled = true
+}
+rule "terraform_required_providers" {
+  enabled = true
+}
+rule "terraform_required_version" {
+  enabled = true
+}
+rule "terraform_standard_module_structure" {
+  enabled = true
+}
+rule "terraform_typed_variables" {
+  enabled = true
+}
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+rule "terraform_workspace_remote" {
+  enabled = true
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/catalog-info.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/catalog-info.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: {% if values.type == 'API' -%}${{ values.type }}{%elif values.type == 'resource' -%}${{ values.type | capitalize }}{% else -%}Component{% endif %}
+metadata:
+  name: ${{ values.name }}
+  title: {% if values.title -%}${{ values.title | dump }}{% else -%}${{ values.name | replace(" ", "-") | lower}}{% endif %}
+  description: ${{ values.description }}
+{%- if values.addLink %}
+  links:
+    - url: ${{ values.addLink }}
+      title: ${{ values.name }}
+      icon: dashboard
+{%- endif -%}
+{%- if(values.tags.length) %}
+  tags:
+  {%- for tag in values.tags %}
+    - ${{ tag }}
+  {%- endfor %}
+{%- endif %}
+  annotations:
+    github.com/project-slug: ${{ values.githubOrg }}/${{ values.githubRepo }}
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: ${{ values.type }}
+  owner: ${{ values.owner }}
+  lifecycle: ${{ values.lifecycle }}
+  {% if values.system %}system: ${{ values.system }}
+  {% endif -%}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/docs/index.md
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/docs/index.md
@@ -1,0 +1,43 @@
+# ${{ values.name }}
+
+${{ values.description }}
+
+The rendered documentation is hosted
+[here.](https://backstage.broadinstitute.org/docs/default/Component/${{values.name}})
+
+## Markdown
+
+Start write your documentation by adding more markdown (`.md`) files to this
+directory or replace the content in this file. For more info see
+[the TechDocs Techdocs](https://backstage.io/docs/features/techdocs/) and
+[TechDocs at Broad.](https://backstage.broadinstitute.org/catalog/default/component/backstage/docs/techdocs/)
+For more information on how to write beautiful markdown, see the [common mark
+spec](https://spec.commonmark.org) or try things out in
+[the dingus.](https://spec.commonmark.org/dingus/)
+
+## Table of Contents
+
+The Table of Contents on the right is generated automatically based on the hierarchy
+of headings. Only use one H1 (`#` in Markdown) per file.
+
+## Site navigation
+
+For new pages to appear in the left hand navigation you need edit the `mkdocs.yml`
+file in root of your repo. The navigation can also link out to other sites.
+
+Alternatively, if there is no `nav` section in `mkdocs.yml`, a navigation section
+will be created for you. However, you will not be able to use alternate titles for
+pages, or include links to other sites.
+
+Note that MkDocs uses `mkdocs.yml`, not `mkdocs.yaml`, although both appear to work.
+See also <https://www.mkdocs.org/user-guide/configuration/>.
+
+## Support
+
+Techdocs is a third-party tool. While BITS encourages maintaining documentation
+about your project, and suggests Techdocs as a means for doing so, we are
+unable to provide technical support regarding its use. If something in this
+document is incorrect or out of date, please file a ticket. For more direct
+support, please reach out in
+[#docs-like-code](https://discord.com/channels/687207715902193673/714754240933003266)
+on Discord.

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/docs/usage.md
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/docs/usage.md
@@ -1,0 +1,144 @@
+# Usage
+
+## Requirements
+
+### Install Terraform
+
+This project uses [Terraform](https://www.terraform.io/) to deploy
+and manage the cloud infrastructure for Google Cloud Storage Transfer Service.
+To execute the automation in this repository,
+[download and install](https://developer.hashicorp.com/terraform/install)
+Terraform following the instructions appropriate to your workstation operating
+system.
+
+BITS also recommends [`tfenv`](https://github.com/tfutils/tfenv) for easier
+management of multiple concurrent versions of Terraform. This can be especially
+useful if you have multiple Terraform projects that each have their own
+specific version requirements. `tfenv` is not required to run anything in this
+repository.
+
+### Set up a GCP project
+
+Before the automation in this repo can be executed, the GCP project
+`${{ values.gcpProject }}` must exist and you must be able to write to it from
+your workstation. To create a new project go to the
+[project creation page](https://console.cloud.google.com/projectcreate) on the
+Google cloud console and fill out the form. You will need a billing account.
+Please be aware that virtually all operations in GCP cost money, and cloud
+bills can add up quickly.
+
+### Authenticate to GCP
+
+Terraform is able to automatically pull credentials from a well-configured
+local `gcloud` CLI to authenticate to GCP. This is the authentication method
+recommended by BITS due to its simplicity and security. You can
+[download and install the `gcloud` CLI](https://cloud.google.com/sdk/docs/install)
+according to the instructions from Google as appropriate for your workstation
+operating system. After installing, run the following commands and follow the
+prompts to authenticate:
+
+```sh
+gcloud init
+gcloud auth application-default login
+```
+
+## Execute Terraform
+
+Hashicorp provides
+[extensive tutorials](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/infrastructure-as-code)
+and [documentation](https://developer.hashicorp.com/terraform/docs) for those
+interested. The automation in this repository, however, requires knowledge of
+only three commands. Run from the project root, they are:
+
+```sh
+terraform -chdir=prod init
+terraform -chdir=prod plan
+terraform -chdir=prod apply
+```
+
+Absent confounding factors, the above three commands run in order will
+completely handle all cloud infrastructure deployment for Google Cloud Storage
+Transfer Service.
+
+### Confounding factors
+
+This list is a work in progress. Please let BITS know if you hit
+any issues with the Terraform deployment that may be generalizable to other
+teams.
+
+#### Pre-existing resources
+
+Terraform expects and requires exclusive control of all cloud resources it
+references, and stores their state. If a resource already exists, or it has
+been manually modified in some way, you may need to import it into Terraform.
+For example, if you have an existing bucket you want to use instead of creating
+a new bucket, you may run:
+
+```
+terraform -chdir=prod import google_storage_bucket.default <bucket-id>
+```
+
+## Set up the agent
+
+In order for Google Cloud Storage Transfer Service to upload from outside GCP,
+it relies on the installation and execution of an agent on the remote system.
+
+### System requirements
+
+In order to install and run the agent, the user on the host system must have:
+
+* podman installed
+* memlock ulimit set to "unlimited", or a value greater than 64Gb
+* A reasonable allotment of subuids and subgids. This template was tested with
+  2 ** 16.
+* Access to space on the local filesystem for storing containers.
+* Access to the desired content for upload (doesn't need to be local).
+
+### Credentials
+
+The Terraform automation will set up a service account, assign correct
+permissions to it, and generate a key. This key will need to be deployed to the
+host server. To access this key, run the following command:
+
+```
+terraform -chdir=prod output service_account_key | base64 -d - > secret.json
+```
+
+*Caution:* Anyone with access to this key will be able to upload arbitrary
+types and amounts of data into your bucket. Once the secret is deployed to the
+server, please delete it from your local machine to prevent accidental
+mishandling.
+
+### Run the agent
+
+The agent is a container and can be downloaded and run with podman. The command
+to do so is:
+
+```
+podman run \
+    --ulimit memlock=64000000 \
+    --detatch \
+    --rm \
+    --volume /local/transfer/logs:/logs \
+    --volume ${{ values.sourceDirectory }}:${{ values.sourceDirectory }} \
+    --volume /local/transfer/key.json:/transfer_root/key.json \
+    gcr.io/cloud-ingest/tsop-agent:latest \
+        --creds-file=/transfer_root/key.json \
+        --hostname="$(hostname)" \
+        --agent-pool=default-pool \
+        --project-id="${{ values.gcpProject }}" \
+        --log-dir=/logs
+```
+
+podman will run this in the background, but it will not persist across reboots.
+If rerunning this command on a quarterly basis is onerous, BITS suggests
+automating the above command with
+[`cron`.](https://www.man7.org/linux/man-pages/man5/crontab.5.html)
+
+## Optimization
+
+This template sets up a minimal working transfer service, but there are many
+ways to enhance performance. See
+[Google's recommendations](https://cloud.google.com/storage-transfer/docs/on-prem-agent-best-practices)
+for a variety of ways to improve this setup if you don't find it meets your
+specifications.

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/mkdocs.yml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/mkdocs.yml
@@ -1,0 +1,9 @@
+---
+site_name: '${{ values.name }} Documentation'
+
+nav:
+  - Home: index.md
+  - Usage: usage.md
+
+plugins:
+  - techdocs-core

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/.terraform-version
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/.terraform-version
@@ -1,0 +1,1 @@
+${{ values.terraformVersion }}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/main.tf
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/main.tf
@@ -1,0 +1,12 @@
+provider "google" {
+  project = var.core_project
+  region  = "${{ values.gcpRegion }}"
+}
+
+resource "google_project_service" "api_services" {
+  for_each                   = toset(var.api_services)
+  project                    = var.core_project
+  service                    = each.key
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/outputs.tf
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/outputs.tf
@@ -1,0 +1,4 @@
+output "service_account_key" {
+  value     = google_service_account_key.default.private_key
+  sensitive = true
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/storage-transfer.tf
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/storage-transfer.tf
@@ -1,0 +1,54 @@
+resource "google_service_account" "default" {
+  account_id = "storage-transfer-service"
+}
+
+resource "google_service_account_key" "default" {
+  service_account_id = "${resource.google_service_account.default.id}"
+}
+
+resource "google_project_iam_member" "default" {
+  project = var.core_project
+  role    = "roles/storagetransfer.transferAgent"
+  member  = resource.google_service_account.default.member
+}
+
+resource "google_storage_transfer_agent_pool" "default" {
+  name         = "default-pool"
+  display_name = "Agent pool for upload job"
+
+  depends_on   = [google_project_iam_member.default]
+}
+
+resource "google_storage_bucket" "default" {
+  name     = "${{ values.gcsBucket }}"
+  location = var.core_region
+}
+
+resource "google_storage_transfer_job" "default" {
+  description = "Upload job"
+
+  transfer_spec {
+    source_agent_pool_name = resource.google_storage_transfer_agent_pool.default.id
+    posix_data_source {
+      root_directory = "${{ values.sourceDirectory }}"
+    }
+    gcs_data_sink {
+      bucket_name = google_storage_bucket.default.name
+      path        = "${{ values.name }}/sink"
+    }
+  }
+  schedule {
+    schedule_start_date {
+      year  = 1
+      month = 1
+      day   = 1
+    }
+    start_time_of_day {
+      hours   = 0
+      minutes = 0
+      seconds = 0
+      nanos   = 0
+    }
+    repeat_interval = "86400s"
+  }
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/terraform.tf
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "${{ values.terraformVersion }}"
+  backend "gcs" {
+    bucket = "${{ values.gcsBucket }}"
+    prefix = "${{ values.name }}/state"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "${{ values.googleProviderVersion }}"
+    }
+  }
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/variables.tf
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/content/prod/variables.tf
@@ -1,0 +1,15 @@
+variable "api_services" {
+  description = "List of API services to enable"
+  type        = list(string)
+  default = [
+    "iam.googleapis.com",
+    "storagetransfer.googleapis.com",
+    "storage.googleapis.com",
+  ]
+}
+
+variable "core_project" {
+  description = "GCP project managed by the default/primary provider"
+  type        = string
+  default     = "${{ values.gcpProject }}"
+}

--- a/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
@@ -10,7 +10,7 @@ metadata:
     provided more generally by `terraform-control-module-template`.
   tags:
     - terraform
-    - GCP
+    - gcp
 
 spec:
   owner: group:devnull
@@ -75,7 +75,7 @@ spec:
           title: List of tags
           type: array
           default:
-            - GCP
+            - gcp
             - terraform
           items:
             type: string

--- a/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
@@ -1,0 +1,227 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: terraform-storage-transfer-template
+  title: Manage Google Cloud Storage Transfer Service using Terraform
+  description: >-
+    This template provides a base for setting up and managing Google Cloud
+    Storage Transfer Service with Terraform. It uses the Terraform conventions
+    provided more generally by `terraform-control-module-template`.
+  tags:
+    - terraform
+    - GCP
+
+spec:
+  owner: group:devnull
+  type: service
+  parameters:
+    - title: Backstage Resource Information
+      required:
+        - name
+        - description
+        - type
+        - lifecycle
+      properties:
+        name:
+          title: Name
+          type: string
+          description: >-
+            A unique identifier for the component. This is how it will be
+            identified in Backstage.
+        title:
+          title: Title
+          type: string
+          description: >-
+            This is a human-readable name for easier discoverability Backstage.
+            If not provided, the name will be used as the title.
+        description:
+          title: Description
+          type: string
+          description: >-
+            This will be viewable in the resource overview in Backstage.
+        type:
+          title: Component type
+          type: string
+          default: service
+          enum:
+            - service
+            - website
+            - resource
+            - documentation
+            - library
+            - API
+          description: >-
+            A high-level category for sorting resources in Backstage.
+        lifecycle:
+          title: Lifecycle phase.
+          type: string
+          default: production
+          enum:
+            - production
+            - experimental
+            - deprecated
+          description: >-
+            A tag describing if/how the component is being used.
+        system:
+          title: System
+          type: string
+          description: >-
+            A system is a collection of resources and components that share a
+            common purpose such as "search", "payments", or "infrastructure".
+            It should be a pre-existing resource in Backstage. If you don't
+            know what to put here, leave it blank.
+        tags:
+          title: List of tags
+          type: array
+          default:
+            - GCP
+            - terraform
+          items:
+            type: string
+            title: Backstage Tags
+          description: >-
+            Arbitrary strings to better sort and find resources in Backstage.
+
+    - title: Github settings
+      required:
+        - githubTeam
+        - repoUrl
+      properties:
+        githubTeam:
+          title: GitHub Team
+          type: string
+          ui:field: OwnerPicker
+          description: The GitHub team that owns the repository.
+          ui:options:
+            catalogFilter:
+              - kind: Group
+                spec.type: team
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          default: github.com?owner=broadinstitute
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - broadinstitute
+
+        visibility:
+          title: Repo Visibility
+          type: string
+          description: >-
+            Should people outside of the Broad be able to see this repo? If
+            you're unsure, please err on the side of caution and leave this
+            setting as 'Private'. It can be changed later.
+          default: private
+          enum:
+            - public
+            - private
+          enumNames:
+            - Public
+            - Private
+
+    - title: Terraform Configuration
+      required:
+        - gcpRegion
+        - gcpProject
+        - gcsBucket
+        - sourceDirectory
+      properties:
+        gcpRegion:
+          title: GCP Region
+          type: string
+          default: us-east4
+          description: >-
+            The default region for the Google provider. If you don't have an
+            existing preference for a specific region, the default will be
+            fine.
+        gcpProject:
+          title: GCP Project
+          type: string
+          description: >-
+            GCP project managed by the default/primary provider.
+            This value will set default values in the template, but will not
+            create new projects or otherwise touch existing projects.
+        gcsBucket:
+          title: GCS Bucket
+          type: string
+          description: >-
+            The name of the GCS bucket to use for this service. It will be used
+            to store Terraform state files as well as be the final upload destination.
+        sourceDirectory:
+          title: Source directory
+          type: string
+          description: >-
+            Absolute path of the directory to be uploaded to the cloud.
+        googleProviderVersion:
+          title: Google Provider Version
+          type: string
+          default: 5.17.0
+          description: >-
+            The version of the Google provider to use in the Terraform
+            configuration. Dependabot will be enabled by default and will open
+            a PR to update this immediately upon creation of the repository.
+        terraformVersion:
+          title: Terraform Version
+          type: string
+          default: 1.7.4
+          description: >-
+            The version of Terraform to use in the Terraform configuration.
+            Dependabot will be enabled by default and will open a PR to update
+            this immediately upon creation of the repository.
+
+  steps:
+    - id: fetchTemplate
+      name: Generate Template
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          description: ${{ parameters.description | dump }}
+          owner: ${{ parameters.githubTeam | parseEntityRef | pick('name') }}
+          tags: ${{ parameters.tags }}
+          type: ${{ parameters.type }}
+          system: ${{ parameters.system }}
+          lifecycle: ${{ parameters.lifecycle }}
+          githubRepo: ${{ parameters.repoUrl | parseRepoUrl | pick('repo') }}
+          githubOrg: ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}
+          gcpRegion: ${{ parameters.gcpRegion }}
+          gcpProject: ${{ parameters.gcpProject }}
+          gcsBucket: ${{ parameters.gcsBucket }}
+          googleProviderVersion: ${{ parameters.googleProviderVersion }}
+          terraformVersion: ${{ parameters.terraformVersion }}
+          title: ${{ parameters.title }}
+          addLink: ${{ parameters.addLink }}
+
+    - id: publish
+      name: Publish to Github
+      action: publish:github
+      input:
+        allowedHosts:
+          - github.com
+        description: ${{ parameters.description }}
+        repoUrl: ${{ parameters.repoUrl }}
+        repoVisibility: ${{ parameters.visibility }}
+        access: >-
+          ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}/${{ parameters.githubTeam | parseEntityRef | pick('name') }}
+        defaultBranch: main
+        requireCodeOwnerReviews: true
+
+    - id: register
+      name: Register the resource to Backstage
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: '/catalog-info.yaml'
+
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}


### PR DESCRIPTION
This template will allow any user at the Broad to set up a minimal Google transfer service without external involvement or maintenance from BITS.