### PR TITLE
feat: Add template for bare documentation repo

### DIFF
--- a/backstage/templates/scaffolder/documentation-repo/content/README.md
+++ b/backstage/templates/scaffolder/documentation-repo/content/README.md
@@ -1,0 +1,1 @@
+docs/index.md

--- a/backstage/templates/scaffolder/documentation-repo/content/catalog-info.yaml
+++ b/backstage/templates/scaffolder/documentation-repo/content/catalog-info.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  title: {% if values.title -%}${{ values.title | dump }}{% else -%}${{ values.name | replace(" ", "-") | lower}}{% endif %}
+  description: ${{ values.description }}
+{%- if values.addLink %}
+  links:
+    - url: ${{ values.addLink }}
+      title: ${{ values.name }}
+      icon: dashboard
+{%- endif -%}
+{%- if(values.tags.length) %}
+  tags:
+  {%- for tag in values.tags %}
+    - ${{ tag }}
+  {%- endfor %}
+{%- endif %}
+  annotations:
+    github.com/project-slug: ${{ values.githubOrg }}/${{ values.githubRepo }}
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: documentation
+  owner: ${{ values.owner }}
+  lifecycle: ${{ values.lifecycle }}
+  {% if values.system %}system: ${{ values.system }}
+  {% endif -%}

--- a/backstage/templates/scaffolder/documentation-repo/content/docs/index.md
+++ b/backstage/templates/scaffolder/documentation-repo/content/docs/index.md
@@ -1,0 +1,43 @@
+# ${{ values.name }}
+
+${{ values.description }}
+
+The rendered documentation is hosted
+[here.](https://backstage.broadinstitute.org/docs/default/Component/${{values.name}})
+
+## Markdown
+
+Start write your documentation by adding more markdown (`.md`) files to this
+directory or replace the content in this file. For more info see
+[the TechDocs Techdocs](https://backstage.io/docs/features/techdocs/) and
+[TechDocs at Broad.](https://backstage.broadinstitute.org/catalog/default/component/backstage/docs/techdocs/)
+For more information on how to write beautiful markdown, see the [common mark
+spec](https://spec.commonmark.org) or try things out in
+[the dingus.](https://spec.commonmark.org/dingus/)
+
+## Table of Contents
+
+The Table of Contents on the right is generated automatically based on the hierarchy
+of headings. Only use one H1 (`#` in Markdown) per file.
+
+## Site navigation
+
+For new pages to appear in the left hand navigation you need edit the `mkdocs.yml`
+file in root of your repo. The navigation can also link out to other sites.
+
+Alternatively, if there is no `nav` section in `mkdocs.yml`, a navigation section
+will be created for you. However, you will not be able to use alternate titles for
+pages, or include links to other sites.
+
+Note that MkDocs uses `mkdocs.yml`, not `mkdocs.yaml`, although both appear to work.
+See also <https://www.mkdocs.org/user-guide/configuration/>.
+
+## Support
+
+Techdocs is a third-party tool. While BITS encourages maintaining documentation
+about your project, and suggests Techdocs as a means for doing so, we are
+unable to provide technical support regarding its use. If something in this
+document is incorrect or out of date, please file a ticket. For more direct
+support, please reach out in
+[#docs-like-code](https://discord.com/channels/687207715902193673/714754240933003266)
+on Discord.

--- a/backstage/templates/scaffolder/documentation-repo/content/mkdocs.yml
+++ b/backstage/templates/scaffolder/documentation-repo/content/mkdocs.yml
@@ -1,0 +1,8 @@
+---
+site_name: '${{ values.name }} Documentation'
+
+nav:
+  - Home: index.md
+
+plugins:
+  - techdocs-core

--- a/backstage/templates/scaffolder/documentation-repo/template.yaml
+++ b/backstage/templates/scaffolder/documentation-repo/template.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: documentation-repo
+  title: Documentation repo with Backstage integration
+  description: >-
+    A repo skeleton for plain documention, viewable in Backstage.
+  tags:
+    - documentation
+
+spec:
+  owner: group:devnull
+  type: documentation
+  parameters:
+    - title: Backstage Resource Information
+      required:
+        - name
+        - description
+        - lifecycle
+      properties:
+        name:
+          title: Name
+          type: string
+          description: >-
+            A unique identifier for the component. This is how it will be
+            identified in Backstage.
+        title:
+          title: Title
+          type: string
+          description: >-
+            This is a human-readable name for easier discoverability Backstage.
+            If not provided, the name will be used as the title.
+        description:
+          title: Description
+          type: string
+          description: >-
+            This will be viewable in the resource overview in Backstage.
+        lifecycle:
+          title: Lifecycle phase.
+          type: string
+          default: production
+          enum:
+            - production
+            - experimental
+            - deprecated
+          description: >-
+            A tag describing if/how the component is being used.
+        system:
+          title: System
+          type: string
+          description: >-
+            A system is a collection of resources and components that share a
+            common purpose such as "search", "payments", or "infrastructure".
+            It should be a pre-existing resource in Backstage. If you don't
+            know what to put here, leave it blank.
+        tags:
+          title: List of tags
+          type: array
+          default:
+            - documentation
+          items:
+            type: string
+            title: Backstage Tags
+          description: >-
+            Arbitrary strings to better sort and find resources in Backstage.
+
+    - title: Github settings
+      required:
+        - githubTeam
+        - repoUrl
+      properties:
+        githubTeam:
+          title: GitHub Team
+          type: string
+          ui:field: OwnerPicker
+          description: The GitHub team that owns the repository.
+          ui:options:
+            catalogFilter:
+              - kind: Group
+                spec.type: team
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          default: github.com?owner=broadinstitute
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - broadinstitute
+
+        visibility:
+          title: Repo Visibility
+          type: string
+          description: >-
+            Should people outside of the Broad be able to see this repo? If
+            you're unsure, please err on the side of caution and leave this
+            setting as 'Private'. It can be changed later.
+          default: private
+          enum:
+            - public
+            - private
+          enumNames:
+            - Public
+            - Private
+
+  steps:
+    - id: fetchTemplate
+      name: Generate Template
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          description: ${{ parameters.description | dump }}
+          owner: ${{ parameters.githubTeam | parseEntityRef | pick('name') }}
+          tags: ${{ parameters.tags }}
+          system: ${{ parameters.system }}
+          lifecycle: ${{ parameters.lifecycle }}
+          githubRepo: ${{ parameters.repoUrl | parseRepoUrl | pick('repo') }}
+          githubOrg: ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}
+          title: ${{ parameters.title }}
+
+    - id: publish
+      name: Publish to Github
+      action: publish:github
+      input:
+        allowedHosts:
+          - github.com
+        description: ${{ parameters.description }}
+        repoUrl: ${{ parameters.repoUrl }}
+        repoVisibility: ${{ parameters.visibility }}
+        access: >-
+          ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}/${{ parameters.githubTeam | parseEntityRef | pick('name') }}
+        defaultBranch: main
+        requireCodeOwnerReviews: true
+
+    - id: register
+      name: Register the resource to Backstage
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: '/catalog-info.yaml'
+
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}


### PR DESCRIPTION
Template out a bare documentation repo, following the example in
https://github.com/broadinstitute/disco-docs, which worked well for me.
