### PR TITLE
feat(auth): add email matching resolver for Google sign-in

### DIFF
--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -101,9 +101,15 @@ auth:
       development:
         clientId: ${AUTH_GOOGLE_CLIENT_ID}
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
       production:
         clientId: ${AUTH_GOOGLE_CLIENT_ID}
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
 
     github:
       development:

--- a/backstage/packages/backend/src/plugins/auth.ts
+++ b/backstage/packages/backend/src/plugins/auth.ts
@@ -1,98 +1,55 @@
 import {
-  createRouter,
-  providers,
-  defaultAuthProviderFactories,
+    createRouter,
+    providers,
+    defaultAuthProviderFactories,
+    getDefaultOwnershipEntityRefs,
 } from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 import {
-  stringifyEntityRef,
-  DEFAULT_NAMESPACE,
+    stringifyEntityRef,
+    DEFAULT_NAMESPACE,
 } from '@backstage/catalog-model';
 
 export default async function createPlugin(
-  env: PluginEnvironment,
+    env: PluginEnvironment,
 ): Promise<Router> {
-  return await createRouter({
-    logger: env.logger,
-    config: env.config,
-    database: env.database,
-    discovery: env.discovery,
-    tokenManager: env.tokenManager,
-    providerFactories: {
-      ...defaultAuthProviderFactories,
+    return await createRouter({
+        logger: env.logger,
+        config: env.config,
+        database: env.database,
+        discovery: env.discovery,
+        tokenManager: env.tokenManager,
+        providerFactories: {
+            ...defaultAuthProviderFactories,
 
-      // This replaces the default GitHub auth provider with a customized one.
-      // The `signIn` option enables sign-in for this provider, using the
-      // identity resolution logic that's provided in the `resolver` callback.
-      //
-      // This particular resolver makes all users share a single "guest" identity.
-      // It should only be used for testing and trying out Backstage.
-      //
-      // If you want to use a production ready resolver you can switch to
-      // the one that is commented out below, it looks up a user entity in the
-      // catalog using the GitHub username of the authenticated user.
-      // That resolver requires you to have user entities populated in the catalog,
-      // for example using https://backstage.io/docs/integrations/github/org
-      //
-      // There are other resolvers to choose from, and you can also create
-      // your own, see the auth documentation for more details:
-      //
-      //   https://backstage.io/docs/auth/identity-resolver
-      // github: providers.github.create({
-      //   signIn: {
-      //     resolver(_, ctx) {
-      //       const userRef = 'user:default/guest'; // Must be a full entity reference
-      //       return ctx.issueToken({
-      //         claims: {
-      //           sub: userRef, // The user's own identity
-      //           ent: [userRef], // A list of identities that the user claims ownership through
-      //         },
-      //       });
-      //     },
-      //     // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
-      //   },
-      // }),
-// File: packages/backend/src/plugins/auth.ts
-      google: providers.google.create({
-        signIn: {
-          resolver: async ({ profile }, ctx) => {
-            if (!profile.email) {
-              throw new Error(
-                'Login failed, user profile does not contain an email',
-              );
-            }
-            // Split the email into the local part and the domain.
-            const [localPart, domain] = profile.email.split('@');
+            google: providers.google.create({
+                signIn: {
+                    resolver: async ({ profile }, ctx) => {
+                        if (!profile.email) {
+                            throw new Error(
+                                'Login failed, user profile does not contain an email',
+                            );
+                        }
+                        // Split the email into the local part and the domain.
+                        const [localPart, domain] = profile.email.split('@');
 
-            // Next we verify the email domain. It is recommended to include this
-            // kind of check if you don't look up the user in an external service.
-            if (domain !== 'broadinstitute.org') {
-              throw new Error(
-                `Login failed, this email ${profile.email} does not belong to the expected domain`,
-              );
-            }
-
-            // By using `stringifyEntityRef` we ensure that the reference is formatted correctly
-            const userEntity = stringifyEntityRef({
-              kind: 'User',
-              name: localPart,
-              namespace: DEFAULT_NAMESPACE,
-            });
-            return ctx.issueToken({
-              claims: {
-                sub: userEntity,
-                ent: [userEntity],
-              },
-            });
-          },
+                        // Next we verify the email domain. It is recommended to include this
+                        // kind of check if you don't look up the user in an external service.
+                        if (domain !== 'broadinstitute.org') {
+                            throw new Error(
+                                `Login failed, this email ${profile.email} does not belong to the expected domain`,
+                            );
+                        }
+                        return ctx.signInWithCatalogUser({
+                            filter: {
+                                kind: ['User'],
+                                'spec.profile.email': profile.email,
+                            },
+                        });
+                    },
+                },
+            }),
         },
-      }),
-      // google: providers.google.create({
-      //   signIn: {
-      //     resolver: providers.google.resolvers.emailLocalPartMatchingUserEntityName(),
-      //   },
-      //}),
-    },
-  });
+    });
 }


### PR DESCRIPTION
Backstage will now sign in the user with the Users catalog entity  based on BI email address.  Since we load user data from github, the BI email will need to exist in the GitHub user info that pull into the catalog.

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
