### PR TITLE
fix: Ssaluja add readiness health check

### DIFF
--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -109,6 +109,7 @@ spec:
               port: 5432
             initialDelaySeconds: 30
             periodSeconds: 30
+	   # to avoid restarting the pod on frequent transient failures.
             failureThreshold: 6
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the

--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -109,7 +109,7 @@ spec:
               port: 5432
             initialDelaySeconds: 30
             periodSeconds: 30
-	    # to avoid restarting the pod on frequent transient failures.
+	    # to avoid restarting the pod on frequent transient failures
             failureThreshold: 6
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the

--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -109,7 +109,7 @@ spec:
               port: 5432
             initialDelaySeconds: 30
             periodSeconds: 30
-	   # to avoid restarting the pod on frequent transient failures.
+	    # to avoid restarting the pod on frequent transient failures.
             failureThreshold: 6
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the

--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -103,6 +103,12 @@ spec:
             # Use auto iam authn to authenticate with the Cloud SQL instance
             - --auto-iam-authn
             - bits-backstage-dev:us-east4:backstage-dev # kpt-set: ${instance_connection_name}
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the
             # "nonroot" user and group (uid: 65532) by default.

--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -108,7 +108,8 @@ spec:
               path: /readiness
               port: 5432
             initialDelaySeconds: 30
-            periodSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 6
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the
             # "nonroot" user and group (uid: 65532) by default.

--- a/deployment/dev/backstage/backstage.yaml
+++ b/deployment/dev/backstage/backstage.yaml
@@ -109,7 +109,6 @@ spec:
               port: 5432
             initialDelaySeconds: 30
             periodSeconds: 30
-	    # to avoid restarting the pod on frequent transient failures
             failureThreshold: 6
           securityContext:
             # The default Cloud SQL Auth Proxy image runs as the


### PR DESCRIPTION
Add readiness health check for cloud-sql-proxy sidecar

The cloud-sql-proxy sidecar container was missing a readiness health
check, which helps Kubernetes manage traffic to the pod only when
the proxy is ready. This commit updates the YAML file to include the
readiness check.

For more details, see the [readiness health check documentation](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/tree/main/examples/k8s-health-check#readiness-health-check-configuration).
