### PR TITLE
feat: Scaffolder Template to add K8s Namespaces

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -91,6 +91,10 @@ catalog:
       target: "https://github.com/broadinstitute/backstage/blob/${BRANCH_NAME}/backstage/templates/scaffolder/add-spack-package/template.yaml"
       rules:
         - allow: [Template]
+    - type: url
+      target: "https://github.com/broadinstitute/backstage/blob/${BRANCH_NAME}/backstage/templates/scaffolder/add-namespace/template.yaml"
+      rules:
+        - allow: [Template]
 
   providers:
     githubOrg:

--- a/backstage/packages/app/src/App.test.tsx
+++ b/backstage/packages/app/src/App.test.tsx
@@ -1,5 +1,21 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
-import { renderWithEffects } from '@backstage/test-utils';
+import { render, waitFor } from '@testing-library/react';
 import App from './App';
 
 describe('App', () => {
@@ -9,8 +25,14 @@ describe('App', () => {
       APP_CONFIG: [
         {
           data: {
-            app: { title: 'Test' },
+            app: {
+              title: 'Test',
+              support: { url: 'http://localhost:7007/support' },
+            },
             backend: { baseUrl: 'http://localhost:7007' },
+            lighthouse: {
+              baseUrl: 'http://localhost:3003',
+            },
             techdocs: {
               storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
             },
@@ -20,7 +42,10 @@ describe('App', () => {
       ] as any,
     };
 
-    const rendered = await renderWithEffects(<App />);
-    expect(rendered.baseElement).toBeInTheDocument();
+    const rendered = render(<App />);
+
+    await waitFor(() => {
+      expect(rendered.baseElement).toBeInTheDocument();
+    });
   });
 });

--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -40,6 +40,7 @@ import { githubAuthApiRef } from '@backstage/core-plugin-api';
 import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 import { SelectFieldFromApiExtension } from '@roadiehq/plugin-scaffolder-frontend-module-http-request-field';
 import { CostInsightsPage } from '@backstage-community/plugin-cost-insights';
+import { GithubTeamPickerExtension } from './scaffolder/GithubTeamPicker/GithubTeamPicker';
 
 interface SignInProviderConfig {
     id: string;
@@ -128,6 +129,7 @@ const routes = (
         >
             <ScaffolderFieldExtensions>
                 <SelectFieldFromApiExtension />
+                <GithubTeamPickerExtension />
             </ScaffolderFieldExtensions>
         </Route>
         <Route path="/api-docs" element={<ApiExplorerPage />} />

--- a/backstage/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.test.tsx
+++ b/backstage/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { CatalogApi } from '@backstage/catalog-client';
+import { GithubTeamPicker } from './GithubTeamPicker';
+import { TestApiProvider } from '@backstage/test-utils';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+import {
+  ErrorApi,
+  IdentityApi,
+  errorApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import userEvent from '@testing-library/user-event';
+import { ScaffolderRJSFFieldProps as FieldProps } from '@backstage/plugin-scaffolder-react';
+
+const mockIdentityApi: IdentityApi = {
+  getProfileInfo: () =>
+    Promise.resolve({
+      displayName: 'Bob',
+      email: 'bob@example.com',
+      picture: 'https://example.com/picture.jpg',
+    }),
+  getBackstageIdentity: () =>
+    Promise.resolve({
+      id: 'Bob',
+      idToken: 'token',
+      type: 'user',
+      userEntityRef: 'user:default/bob',
+      ownershipEntityRefs: ['group:default/group1', 'group:default/group2'],
+    }),
+  getCredentials: () => Promise.resolve({ token: 'token' }),
+  signOut: () => Promise.resolve(),
+};
+
+describe('<GithubTeamPicker />', () => {
+  let entities: Entity[];
+  const onChange = jest.fn();
+  const schema = {};
+  const required = false;
+
+  const catalogApi: jest.Mocked<CatalogApi> = {
+    getEntities: jest.fn(async () => ({ items: entities })),
+  } as any;
+
+  const mockErrorApi: jest.Mocked<ErrorApi> = {
+    post: jest.fn(),
+    error$: jest.fn(),
+  };
+
+  beforeEach(() => {
+    entities = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group1' },
+        spec: { members: ['Bob'] },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group2' },
+        spec: { members: ['Bob'] },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group3' },
+        spec: { members: ['Alice'] },
+      },
+    ];
+
+    onChange.mockClear();
+    catalogApi.getEntities.mockClear();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should only return teams the user is a member of', async () => {
+    const teams = entities.filter(
+      entity =>
+        entity.spec &&
+        Array.isArray(entity.spec.members) &&
+        entity.spec.members.includes('Bob'),
+    );
+
+    catalogApi.getEntities.mockResolvedValue({ items: teams });
+    const props = {
+      onChange,
+      schema,
+      required,
+    } as unknown as FieldProps<string>;
+
+    render(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+        ]}
+      >
+        <GithubTeamPicker {...props} />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+    );
+
+    expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      filter: {
+        kind: 'Group',
+        'relations.hasMember': ['user:default/bob'],
+      },
+    });
+
+    await expect(catalogApi.getEntities.mock.results[0].value).resolves.toEqual(
+      {
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: { name: 'group1' },
+            spec: { members: ['Bob'] },
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: { name: 'group2' },
+            spec: { members: ['Bob'] },
+          },
+        ],
+      },
+    );
+
+    await expect(
+      catalogApi.getEntities.mock.results[0].value,
+    ).resolves.not.toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            metadata: { name: 'group3' },
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('should display the github teams the user is a part of', async () => {
+    const userTeams = entities.filter(
+      entity =>
+        entity.spec &&
+        Array.isArray(entity.spec.members) &&
+        entity.spec.members.includes('Bob'),
+    );
+
+    catalogApi.getEntities.mockResolvedValue({ items: userTeams });
+
+    const props = {
+      onChange,
+      schema,
+      required,
+    } as unknown as FieldProps<string>;
+
+    const { queryByText, getByRole } = render(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+        ]}
+      >
+        <GithubTeamPicker {...props} />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+    );
+
+    const inputField = getByRole('combobox');
+    await userEvent.click(inputField);
+    await userEvent.type(inputField, 'group');
+
+    await waitFor(() => {
+      const group1Elem = queryByText('group1');
+      const group2Elem = queryByText('group2');
+      expect(group1Elem).toBeInTheDocument();
+      expect(group2Elem).toBeInTheDocument();
+    });
+  });
+});

--- a/backstage/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
+++ b/backstage/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
@@ -1,0 +1,106 @@
+import { Entity } from '@backstage/catalog-model';
+import {
+  useApi,
+  identityApiRef,
+  errorApiRef,
+} from '@backstage/core-plugin-api';
+import {
+  catalogApiRef,
+  humanizeEntityRef,
+} from '@backstage/plugin-catalog-react';
+import { TextField, FormControl } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import React, { useState } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { GithubTeamPickerProps } from './schema';
+
+export const GithubTeamPicker = (props: GithubTeamPickerProps) => {
+  const {
+    schema: { title, description },
+    required,
+    rawErrors,
+    onChange,
+  } = props;
+
+  const identityApi = useApi(identityApiRef);
+  const catalogApi = useApi(catalogApiRef);
+  const errorApi = useApi(errorApiRef);
+  const [teams, setTeams] = useState<
+    {
+      label: string;
+      ref: string;
+    }[]
+  >([]);
+  const [selectedTeam, setSelectedTeam] = useState<null | {
+    label: string;
+    ref: string;
+  }>(null);
+
+  useAsync(async () => {
+    const { userEntityRef } = await identityApi.getBackstageIdentity();
+
+    if (!userEntityRef) {
+      errorApi.post(new Error('No user entity ref found'));
+      return;
+    }
+
+    const { items } = await catalogApi.getEntities({
+      filter: {
+        kind: 'Group',
+        ['relations.hasMember']: [userEntityRef],
+      },
+    });
+
+    const githubTeams = items
+      .filter((e): e is Entity => Boolean(e))
+      .map(team => ({
+        label: team.metadata.title ?? team.metadata.name,
+        ref: humanizeEntityRef(team, {
+          defaultKind: 'Group',
+          defaultNamespace: 'default',
+        }),
+      }));
+
+    setTeams(githubTeams);
+  });
+
+  const updateChange = (
+    _: React.ChangeEvent<{}>,
+    value: { label: string; ref: string } | null,
+  ) => {
+    setSelectedTeam(value);
+    onChange(value?.ref ?? '');
+  };
+
+  return (
+    <FormControl margin="normal" required error={rawErrors?.length > 0}>
+      <Autocomplete
+        id="GithubTeamPicker"
+        options={teams || []}
+        value={selectedTeam}
+        onChange={updateChange}
+        getOptionLabel={team => team.label}
+        renderInput={params => (
+          <TextField
+            {...params}
+            label={title}
+            margin="dense"
+            required={required}
+            helperText={description}
+            variant="outlined"
+            FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
+          />
+        )}
+      />
+    </FormControl>
+  );
+};
+
+export const GithubTeamPickerExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'GithubTeamPicker',
+    component: GithubTeamPicker,
+  }),
+);

--- a/backstage/packages/app/src/scaffolder/GithubTeamPicker/schema.ts
+++ b/backstage/packages/app/src/scaffolder/GithubTeamPicker/schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { makeFieldSchemaFromZod } from '@backstage/plugin-scaffolder';
+
+export const GithubTeamPickerFieldSchema = makeFieldSchemaFromZod(
+  z.string(),
+  z.object({
+    title: z.string().default('Github Team').describe('Github Team'),
+    desciption: z
+      .string()
+      .default('Select a Github Team')
+      .describe('Select a Github Team'),
+  }),
+);
+
+/**
+ * UI options for the Github Team Picker.
+ * @public
+ */
+
+export type GithubTeamPickerUiOptions =
+  typeof GithubTeamPickerFieldSchema.uiOptionsType;
+
+/**
+ * Props for the GithubTeamPicker.
+ * @public
+ */
+
+export type GithubTeamPickerProps = typeof GithubTeamPickerFieldSchema.type;
+
+/**
+ * Schema for the GithubTeamPicker.
+ * @public
+ */
+
+export const GithubTeamPickerSchema = GithubTeamPickerFieldSchema.schema;

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -36,13 +36,22 @@ spec:
           description: >-
             Name of the namespace to create. Must be unique. for example: "myapp-prod"
         teams:
-          title: 'Namespace Admin Groups'
+          title: 'Namespace Admins'
           type: array
           description: >-
             List of ***Google Groups*** to add to the namespace. At least one group is required.
+            Please insure that your Google Group is added to the
+            [gke-security-groups](https://groups.google.com/a/broadinstitute.org/g/gke-security-groups) group.
+            More information can be found on the
+            [Configure Google Groups for RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac#:~:text=Add%20your%20groups%20as%20nested%20groups%20to%20the%20gke%2Dsecurity%2Dgroups%20group.%20Don%27t%20add%20individual%20users%20as%20members%20of%20gke%2Dsecurity%2Dgroups.) page.
           items:
             type: string
             title: Google Groups
+            pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
+      errorMessage:
+        properties:
+          teams: 'Must be validate email addresses'
+
   steps:
     - action: roadiehq:utils:serialize:yaml
       id: Namespace
@@ -99,16 +108,16 @@ spec:
     #   input:
     #     listWorkspace: true
 
-    - id: createPullRequest
-      name: createPullRequest
-      action: publish:github:pull-request
-      input:
-        repoUrl: 'github.com?repo=kubernetes-configs=broadinstitute'
-        branchName: add-${{ parameters.namespace }}-namespace
-        title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
-        description: >-
-          This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
-          On behalf of the ${{ parameters.owners }} team.
+    # - id: createPullRequest
+    #   name: createPullRequest
+    #   action: publish:github:pull-request
+    #   input:
+    #     repoUrl: 'github.com?repo=kubernetes-configs=broadinstitute'
+    #     branchName: add-${{ parameters.namespace }}-namespace
+    #     title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
+    #     description: >-
+    #       This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
+    #       On behalf of the ${{ parameters.owners }} team.
   output:
     links:
       - title: View the pull request on GitHub

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -26,6 +26,8 @@ spec:
         owners:
           title: 'GitHub Owners'
           type: string
+          ui:field: GithubTeamPicker
+          ui:autofocus: true
           description: >-
             Name of the GitHub team that is responsible the namespace. for example: "myapp-prod"
         namespace:

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: add-namespace
   title: "Add kubernetes namespace for your team"
   description: >-
-    Create a new Pull Request to add a new namespace to the Kubernetes cluster.
+    Create a new Pull Request to add a new namespace to the `bits-gke-clusters` Kubernetes environment.
     In addition to the namespace, the PR will add permissions for the namespace
     to the team's Google Group.
   tags:
@@ -29,12 +29,12 @@ spec:
           ui:field: GithubTeamPicker
           ui:autofocus: true
           description: >-
-            Name of the GitHub team that is responsible the namespace. for example: "myapp-prod"
+            ***GitHub team*** responsible for the namespace.
         namespace:
           title: Kubernetes Namespace
           type: string
           description: >-
-            Name of the namespace to create. Must be unique. for example: "myapp-prod"
+            Namespace to create. Must be unique across the `bits-gke-clusters` Kubernetes environment.
         teams:
           title: 'Namespace Admins'
           type: array
@@ -50,7 +50,7 @@ spec:
             pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
       errorMessage:
         properties:
-          teams: 'Must be validate email addresses'
+          teams: 'Must be a valid email address'
 
   steps:
     - action: roadiehq:utils:serialize:yaml
@@ -117,12 +117,6 @@ spec:
         content: |
           # ${{ parameters.namespace }} namespace
           /manifests/namespace/${{ parameters.namespace }}/* @broadinstitute/${{ parameters.owners }}
-
-    # - action: debug:log
-    #   id: write-workspace-directory
-    #   name: List the workspace directory with file contents
-    #   input:
-    #     listWorkspace: true
 
     - id: createPullRequest
       name: createPullRequest

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -53,7 +53,7 @@ spec:
             name: ${{ parameters.namespace }}
 
     - id: writeNamespace
-      name: Create Namespace YAML File
+      name: Write Namespace YAML File
       action: roadiehq:utils:fs:write
       input:
         path: manifests/namespace/${{ parameters.namespace }}/namespace.yaml
@@ -80,22 +80,22 @@ spec:
 
     - action: roadiehq:utils:serialize:yaml
       id: serializeRoleBinding
-      name: Create RoleBinding for Namespace Admins
+      name: Serialize RoleBinding for Namespace Admins
       input:
         data: ${{ steps.parseRoleBinding.output.result }}
 
     - id: writeRoleBinding
-      name: Create Namespace Admin RoleBinding YAML File
+      name: Write Namespace Admin RoleBinding YAML File
       action: roadiehq:utils:fs:write
       input:
         path: manifests/namespace/${{ parameters.namespace }}/namespace-admin.yaml
         content: ${{ steps.serializeRoleBinding.output.serialized }}
 
-    - action: debug:log
-      id: write-workspace-directory
-      name: List the workspace directory with file contents
-      input:
-        listWorkspace: true
+    # - action: debug:log
+    #   id: write-workspace-directory
+    #   name: List the workspace directory with file contents
+    #   input:
+    #     listWorkspace: true
 
     - id: createPullRequest
       name: createPullRequest

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: add-namespace
+  title: "Add kubernetes namespace for your team"
+  description: >-
+    Create a new Pull Request to add a new namespace to the Kubernetes cluster.
+    In addition to the namespace, the PR will add permissions for the namespace
+    to the team's Google Group.
+  tags:
+    - recommended
+    - kubernetes
+
+spec:
+  owner: group:devnull
+  type: service
+
+  parameters:
+    - title: Package Information
+      required:
+        - namespace
+        - teams
+        - owners
+      properties:
+        owners:
+          title: 'GitHub Owners'
+          type: string
+          description: >-
+            Name of the GitHub team that is responsible the namespace. for example: "myapp-prod"
+        namespace:
+          title: Kubernetes Namespace
+          type: string
+          description: >-
+            Name of the namespace to create. Must be unique. for example: "myapp-prod"
+        teams:
+          title: 'Namespace Admin Groups'
+          type: array
+          description: >-
+            List of ***Google Groups*** to add to the namespace. At least one group is required.
+          items:
+            type: string
+            title: Google Groups
+  steps:
+    - action: roadiehq:utils:serialize:yaml
+      id: Namespace
+      name: Create Namespace
+      input:
+        data:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ${{ parameters.namespace }}
+
+    - id: writeNamespace
+      name: Create Namespace YAML File
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/${{ parameters.namespace }}/namespace.yaml
+        content: ${{ steps.Namespace.output.serialized }}
+
+    - id: parseRoleBinding
+      name: Parse RoleBinding for Namespace Admins File
+      action: roadiehq:utils:jsonata
+      input:
+        data:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: namespace-admins
+            namespace: ${{ parameters.namespace }}
+          subjects:
+            - kind: Group
+              name: devnull@broadinstitute.org
+          roleRef:
+            kind: ClusterRole
+            name: namespace-admin
+            apiGroup: rbac.authorization.k8s.io
+        expression: '$ ~> | $ | { "subjects":  $reduce($map($split("${{ parameters.teams }}", ","), function($v) { { "kind": "Group", "name": $v } }), $append, []) } |'
+
+    - action: roadiehq:utils:serialize:yaml
+      id: serializeRoleBinding
+      name: Create RoleBinding for Namespace Admins
+      input:
+        data: ${{ steps.parseRoleBinding.output.result }}
+
+    - id: writeRoleBinding
+      name: Create Namespace Admin RoleBinding YAML File
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/${{ parameters.namespace }}/namespace-admin.yaml
+        content: ${{ steps.serializeRoleBinding.output.serialized }}
+
+    - action: debug:log
+      id: write-workspace-directory
+      name: List the workspace directory with file contents
+      input:
+        listWorkspace: true
+
+    - id: createPullRequest
+      name: createPullRequest
+      action: publish:github:pull-request
+      input:
+        repoUrl: 'github.com?repo=kubernetes-configs=broadinstitute'
+        branchName: add-${{ parameters.namespace }}-namespace
+        title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
+        description: >-
+          This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
+          On behalf of the ${{ parameters.owners }} team.
+  output:
+    links:
+      - title: View the pull request on GitHub
+        icon: github
+        url: ${{ steps['createPullRequest'].output.remoteUrl }}

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -116,7 +116,7 @@ spec:
         path: .github/CODEOWNERS
         content: |
           # ${{ parameters.namespace }} namespace
-          /manifests/namespace/${{ parameters.namespace }}/* @${{ parameters.owners }}
+          /manifests/namespace/${{ parameters.namespace }}/* @broadinstitute/${{ parameters.owners }}
 
     # - action: debug:log
     #   id: write-workspace-directory
@@ -130,7 +130,7 @@ spec:
       input:
         repoUrl: 'github.com?repo=kubernetes-configs&owner=broadinstitute'
         branchName: add-${{ parameters.namespace }}-namespace
-        title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
+        title: 'feat: Add ${{ parameters.namespace }} Namespace for ${{ parameters.owners }}'
         description: >-
           This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
           On behalf of the ${{ parameters.owners }} team.

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -102,22 +102,38 @@ spec:
         path: manifests/namespace/${{ parameters.namespace }}/namespace-admin.yaml
         content: ${{ steps.serializeRoleBinding.output.serialized }}
 
+    - action: fetch:plain:file
+      id: fetchFile
+      name: Fetch CODEOWNERS file
+      input:
+        url: https://github.com/broadinstitute/kubernetes-configs/blob/main/.github/CODEOWNERS
+        targetPath: .github/CODEOWNERS
+
+    - action: roadiehq:utils:fs:append
+      id: appendCodeowners
+      name: Append GitHub Team to CODEOWNERS file
+      input:
+        path: .github/CODEOWNERS
+        content: |
+          # ${{ parameters.namespace }} namespace
+          /manifests/namespace/${{ parameters.namespace }}/* @${{ parameters.owners }}
+
     # - action: debug:log
     #   id: write-workspace-directory
     #   name: List the workspace directory with file contents
     #   input:
     #     listWorkspace: true
 
-    # - id: createPullRequest
-    #   name: createPullRequest
-    #   action: publish:github:pull-request
-    #   input:
-    #     repoUrl: 'github.com?repo=kubernetes-configs=broadinstitute'
-    #     branchName: add-${{ parameters.namespace }}-namespace
-    #     title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
-    #     description: >-
-    #       This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
-    #       On behalf of the ${{ parameters.owners }} team.
+    - id: createPullRequest
+      name: createPullRequest
+      action: publish:github:pull-request
+      input:
+        repoUrl: 'github.com?repo=kubernetes-configs&owner=broadinstitute'
+        branchName: add-${{ parameters.namespace }}-namespace
+        title: 'feat: Add ${{ parameters.namespace }} for ${{ parameters.owners }}'
+        description: >-
+          This PR adds the ${{ parameters.namespace }} namespace to the Kubernetes cluster.
+          On behalf of the ${{ parameters.owners }} team.
   output:
     links:
       - title: View the pull request on GitHub

--- a/backstage/templates/scaffolder/add-spack-package/template.yaml
+++ b/backstage/templates/scaffolder/add-spack-package/template.yaml
@@ -52,70 +52,43 @@ spec:
             Google Group Email address of the team or lab requesting the package.
 
   steps:
-    - action: fetch:plain
-      id: fetch-plain
-      name: Fetch plain
+    - id: parsePackageFile
+      name: Parse Spack Package File
+      action: roadiehq:utils:jsonata
       input:
-        url: ./content
-
-    - id: set-name
-      name: Set Package Name
-      action: roadiehq:utils:jsonata:yaml:transform
-      input:
-        path: ./spack/packages/package.yaml
-        expression: '$ ~> | $ | { "metadata": { "name": "${{ parameters.name}}" } } |'
-
-    - id: WriteName
-      name: Write File
-      action: roadiehq:utils:merge
-      input:
-        path: ./spack/packages/package.yaml
-        content: ${{ steps['set-name'].output.result }}
-
-    - id: set-owners
-      name: Set Package Owners
-      action: roadiehq:utils:jsonata:yaml:transform
-      input:
-        path: ./spack/packages/package.yaml
-        expression: '$ ~> | $ | { "spec": { "owners": [{ "name": "${{ parameters.owners }}", "email": "${{ parameters.email }}" }] } } |'
-
-    - id: WriteOwners
-      name: Write File
-      action: roadiehq:utils:merge
-      input:
-        path: ./spack/packages/package.yaml
-        content: ${{ steps['set-owners'].output.result }}
-
-    - id: set-versions
-      name: Set Package Versions
-      action: roadiehq:utils:jsonata:yaml:transform
-      if: ${{ parameters.versions }}
-      input:
-        path: ./spack/packages/package.yaml
         expression: '$ ~> | $ | { "spec": { "package_versions": $reduce($map($split("${{ parameters.versions }}", ","), function($v) { { "name": $v } }), $append, []) } } |'
+        data:
+          apiVersion: bits-package.dev/v1
+          kind: SpackPackage
+          metadata:
+            name: ${{ parameters.name }}
+          spec:
+            owners:
+              - name: ${{ parameters.owners }}
+                email: ${{ parameters.email }}
+            package_versions:
+              - name: 0.0.0
+            source: spack-public
+            type: spack
 
-    - id: WriteVersions
-      name: Write File
-      action: roadiehq:utils:merge
-      if: ${{ parameters.versions }}
+    - action: roadiehq:utils:serialize:yaml
+      id: serializePackageFile
+      name: Serialize The Package File
       input:
-        path: ./spack/packages/package.yaml
-        content: ${{ steps['set-versions'].output.result }}
+        data: ${{ steps.parsePackageFile.output.result }}
 
-    - action: fs:rename
-      id: renameFiles
-      name: Rename file
+    - id: writePackageFile
+      name: Create Package YAML File
+      action: roadiehq:utils:fs:write
       input:
-        files:
-          - from: ./spack/packages/package.yaml
-            to: ./spack/packages/${{ parameters.name }}.yaml
+        path: spack/packages/${{ parameters.name }}.yaml
+        content: ${{ steps.serializePackageFile.output.serialized }}
 
-    - action: debug:log
-      id: write-workspace-directory
-      name: List the workspace directory with file contents
-      input:
-        listWorkspace: true
-
+    # - action: debug:log
+    #   id: write-workspace-directory
+    #   name: List the workspace directory with file contents
+    #   input:
+    #     listWorkspace: true
 
     - id: createPullRequest
       name: createPullRequest

--- a/backstage/templates/scaffolder/add-spack-package/template.yaml
+++ b/backstage/templates/scaffolder/add-spack-package/template.yaml
@@ -50,6 +50,11 @@ spec:
           type: string
           description: >-
             Google Group Email address of the team or lab requesting the package.
+          pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
+      errorMessage:
+        properties:
+          email: 'Must be validate email addresses'
+
 
   steps:
     - id: parsePackageFile

--- a/backstage/templates/scaffolder/add-spack-package/template.yaml
+++ b/backstage/templates/scaffolder/add-spack-package/template.yaml
@@ -53,7 +53,7 @@ spec:
           pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
       errorMessage:
         properties:
-          email: 'Must be validate email addresses'
+          email: 'Must be a valid email address'
 
 
   steps:
@@ -88,12 +88,6 @@ spec:
       input:
         path: spack/packages/${{ parameters.name }}.yaml
         content: ${{ steps.serializePackageFile.output.serialized }}
-
-    # - action: debug:log
-    #   id: write-workspace-directory
-    #   name: List the workspace directory with file contents
-    #   input:
-    #     listWorkspace: true
 
     - id: createPullRequest
       name: createPullRequest


### PR DESCRIPTION
This PR automates the process outlined in the Kuberntes [docs](https://backstage.broadinstitute.org/docs/default/component/kubernetes-configs/create-namespace/) on how to on-board your team to our Kube clusters. 

This PR also refactors some of the add spack package template to include some of the jsonata / action kung-fu I learned


---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
