### PR TITLE
fix: System & domain steps to catalog-info

### DIFF
--- a/backstage/templates/scaffolder/defaults/steps/domain-write.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/domain-write.yaml
@@ -1,0 +1,7 @@
+id: domainWriteFile
+name: Update catalog-info.yaml with Domain
+action: roadiehq:utils:merge
+if: ${{ parameters.domain }}
+input:
+  path: catalog-info.yaml
+  content: ${{ steps['addDomain'].output.result }}

--- a/backstage/templates/scaffolder/defaults/steps/domain.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/domain.yaml
@@ -1,0 +1,7 @@
+id: addDomain
+name: Add Domain to catalog-info.yaml
+action: roadiehq:utils:jsonata:yaml:transform
+if: ${{ parameters.domain }}
+input:
+  path: catalog-info.yaml
+  expression: '$ ~> | $ | { "spec": { "domain": "${{ parameters.domain | parseEntityRef | pick("name") }}" } } |'

--- a/backstage/templates/scaffolder/defaults/steps/system-write.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/system-write.yaml
@@ -1,0 +1,7 @@
+id: systemWriteFile
+name: Update catalog-info.yaml with System
+action: roadiehq:utils:merge
+if: ${{ parameters.system }}
+input:
+  path: catalog-info.yaml
+  content: ${{ steps['addSystem'].output.result }}

--- a/backstage/templates/scaffolder/defaults/steps/system.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/system.yaml
@@ -1,0 +1,7 @@
+id: addSystem
+name: Add System to catalog-info.yaml
+action: roadiehq:utils:jsonata:yaml:transform
+if: ${{ parameters.system }}
+input:
+  path: catalog-info.yaml
+  expression: '$ ~> | $ | { "spec": { "system": "${{ parameters.system | parseEntityRef | pick("name") }}" } } |'

--- a/backstage/templates/scaffolder/defaults/steps/write-catalog.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/write-catalog.yaml
@@ -21,5 +21,3 @@ input:
       type: ${{ parameters.type | lower }}
       lifecycle: ${{ parameters.lifecycle }}
       owner: ${{ parameters.githubTeam | parseEntityRef | pick('name') }}
-      system: ${{ parameters.system | parseEntityRef | pick('name') }}
-      domain: ${{ parameters.domain | parseEntityRef | pick('name') }}

--- a/backstage/templates/scaffolder/example/template.yaml
+++ b/backstage/templates/scaffolder/example/template.yaml
@@ -269,11 +269,41 @@ spec:
             type: ${{ parameters.type | lower }}
             lifecycle: ${{ parameters.lifecycle }}
             owner: ${{ parameters.githubTeam | parseEntityRef | pick('name') }}
-            system: ${{ parameters.system | parseEntityRef | pick('name') }}
-            domain: ${{ parameters.domain | parseEntityRef | pick('name') }}
     # End steps/write-catalog.yaml
     # Add annotations to the catalog-info.yaml file if the user has selected to add them
     # Start steps/annotations/<name>.yaml
+    - id: addSystem
+      name: Add System to catalog-info.yaml
+      action: roadiehq:utils:jsonata:yaml:transform
+      if: ${{ parameters.system }}
+      input:
+        path: catalog-info.yaml
+        expression: '$ ~> | $ | { "spec": { "system": "${{ parameters.system | parseEntityRef | pick("name") }}" } } |'
+
+    - id: systemWriteFile
+      name: Update catalog-info.yaml with System
+      action: roadiehq:utils:merge
+      if: ${{ parameters.system }}
+      input:
+        path: catalog-info.yaml
+        content: ${{ steps['addSystem'].output.result }}
+
+    - id: addDomain
+      name: Add Domain to catalog-info.yaml
+      action: roadiehq:utils:jsonata:yaml:transform
+      if: ${{ parameters.domain }}
+      input:
+        path: catalog-info.yaml
+        expression: '$ ~> | $ | { "spec": { "domain": "${{ parameters.domain | parseEntityRef | pick("name") }}" } } |'
+
+    - id: domainWriteFile
+      name: Update catalog-info.yaml with Domain
+      action: roadiehq:utils:merge
+      if: ${{ parameters.domain }}
+      input:
+        path: catalog-info.yaml
+        content: ${{ steps['addDomain'].output.result }}
+
     - id: techdocsAnnotation
       name: TechDocs Annotation
       action: roadiehq:utils:jsonata:yaml:transform

--- a/backstage/templates/scaffolder/pr-with-catalog-entry/template.yaml
+++ b/backstage/templates/scaffolder/pr-with-catalog-entry/template.yaml
@@ -45,6 +45,10 @@ spec:
 
   steps:
     - $yaml: ../defaults/steps/write-catalog.yaml
+    - $yaml: ../defaults/steps/system.yaml
+    - $yaml: ../defaults/steps/system-write.yaml
+    - $yaml: ../defaults/steps/domain.yaml
+    - $yaml: ../defaults/steps/domain-write.yaml
     - $yaml: ../defaults/steps/annotations/techdocs.yaml
     - $yaml: ../defaults/steps/annotations/techdocs-write.yaml
     - $yaml: ../defaults/steps/annotations/kubernetes.yaml

--- a/backstage/templates/scaffolder/python-package/template.yaml
+++ b/backstage/templates/scaffolder/python-package/template.yaml
@@ -88,6 +88,10 @@ spec:
           githubOrg: ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}
 
     - $yaml: ../defaults/steps/write-catalog.yaml
+    - $yaml: ../defaults/steps/system.yaml
+    - $yaml: ../defaults/steps/system-write.yaml
+    - $yaml: ../defaults/steps/domain.yaml
+    - $yaml: ../defaults/steps/domain-write.yaml
     - $yaml: ../defaults/steps/annotations/techdocs.yaml
     - $yaml: ../defaults/steps/annotations/techdocs-write.yaml
     - $yaml: ../defaults/steps/annotations/kubernetes.yaml

--- a/backstage/templates/scaffolder/terraform-control-module/template.yaml
+++ b/backstage/templates/scaffolder/terraform-control-module/template.yaml
@@ -127,6 +127,10 @@ spec:
           title: ${{ parameters.title }}
 
     - $yaml: ../defaults/steps/write-catalog.yaml
+    - $yaml: ../defaults/steps/system.yaml
+    - $yaml: ../defaults/steps/system-write.yaml
+    - $yaml: ../defaults/steps/domain.yaml
+    - $yaml: ../defaults/steps/domain-write.yaml
     - $yaml: ../defaults/steps/annotations/techdocs.yaml
     - $yaml: ../defaults/steps/annotations/techdocs-write.yaml
     - $yaml: ../defaults/steps/annotations/kubernetes.yaml

--- a/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
@@ -123,6 +123,10 @@ spec:
           terraformVersion: ${{ parameters.terraformVersion }}
 
     - $yaml: ../defaults/steps/write-catalog.yaml
+    - $yaml: ../defaults/steps/system.yaml
+    - $yaml: ../defaults/steps/system-write.yaml
+    - $yaml: ../defaults/steps/domain.yaml
+    - $yaml: ../defaults/steps/domain-write.yaml
     - $yaml: ../defaults/steps/annotations/techdocs.yaml
     - $yaml: ../defaults/steps/annotations/techdocs-write.yaml
     - $yaml: ../defaults/steps/annotations/kubernetes.yaml

--- a/backstage/templates/scaffolder/terraform-with-terragrunt/template.yaml
+++ b/backstage/templates/scaffolder/terraform-with-terragrunt/template.yaml
@@ -174,6 +174,10 @@ spec:
           title: ${{ parameters.title }}
 
     - $yaml: ../defaults/steps/write-catalog.yaml
+    - $yaml: ../defaults/steps/system.yaml
+    - $yaml: ../defaults/steps/system-write.yaml
+    - $yaml: ../defaults/steps/domain.yaml
+    - $yaml: ../defaults/steps/domain-write.yaml
     - $yaml: ../defaults/steps/annotations/techdocs.yaml
     - $yaml: ../defaults/steps/annotations/techdocs-write.yaml
     - $yaml: ../defaults/steps/annotations/kubernetes.yaml


### PR DESCRIPTION
System and Domain were incorrectly being created when they were null
ex.
https://github.com/broadinstitute/bits-bt-ai/pull/23/files#diff-47e4499e7f2830df90da07ca1636ba625c6a700eedc9671dfc2f7ca69fed42feR19-R20

Since the write-catalog step doesn't allow for conditionals, I broke them out into separate steps, which isn't ideal but generates the file correctly
example of a file generated with the updates

https://github.com/broadinstitute/terraform-alaric-sandbox/blob/backstage-integration/catalog-info.yaml

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
