### PR TITLE
fix:  JSONata to merge package versions

### DIFF
--- a/backstage/templates/scaffolder/add-spack-package/template.yaml
+++ b/backstage/templates/scaffolder/add-spack-package/template.yaml
@@ -61,7 +61,7 @@ spec:
       name: Parse Spack Package File
       action: roadiehq:utils:jsonata
       input:
-        expression: '$ ~> | $ | { "spec": { "package_versions": $reduce($map($split("${{ parameters.versions }}", ","), function($v) { { "name": $v } }), $append, []) } } |'
+        expression: '$ ~> | $ | { "spec": $merge([spec, { "package_versions": $reduce($map($split("${{ parameters.versions }}", ","), function($v) { { "name": $v } }), $append, []) }]) } |'
         data:
           apiVersion: bits-package.dev/v1
           kind: SpackPackage


### PR DESCRIPTION
This way the ouptut includes all the fields we need.
 For example, pre fix:

```yaml
apiVersion: bits-package.dev/v1
kind: SpackPackage
metadata:
  name: openmm
spec:
  package_versions:
    - name: 8.0.0
    - name: "7.0"
```

post fix:
```Yaml
apiVersion: bits-package.dev/v1
kind: SpackPackage
metadata:
  name: openmm
spec:
  owners:
    - name: devnull
      email: devnull@foo.com
  package_versions:
    - name: 8.0.0
    - name: "7.0"
  source: spack-public
  type: spack
```

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
