### PR TITLE
fix: Enhance GitHub repo settings for publishing

### DIFF
--- a/backstage/templates/scaffolder/defaults/steps/publish.yaml
+++ b/backstage/templates/scaffolder/defaults/steps/publish.yaml
@@ -10,6 +10,9 @@ input:
   access: >-
     ${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}/${{ parameters.githubTeam | parseEntityRef | pick('name') }}
   defaultBranch: main
+  protectDefaultBranch: true
+  protectEnforceAdmins: true
   requireCodeOwnerReviews: true
   allowMergeCommit: true
   allowSquashMerge: true
+  allowRebaseMerge: true


### PR DESCRIPTION
Set some of the defaults explicitly in order to pass soundcheck checks on creation

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
