### PR TITLE
fix: Google Groups input for namespace template

### DIFF
--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -49,9 +49,9 @@ spec:
             type: string
             title: Google Groups
             pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
-      errorMessage:
-        properties:
-          teams: 'Must be a valid email address'
+            ui:help: 'Enter a valid Google Group email address'
+            ui:hideError: true
+            default: 'google-group@broadinstitute.org'
 
   steps:
     - action: roadiehq:utils:serialize:yaml

--- a/backstage/templates/scaffolder/add-spack-package/template.yaml
+++ b/backstage/templates/scaffolder/add-spack-package/template.yaml
@@ -52,11 +52,9 @@ spec:
           description: >-
             Google Group Email address of the team or lab requesting the package.
           pattern: '^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$'
-      errorMessage:
-        properties:
-          email: 'Must be a valid email address'
-
-
+          ui:help: 'Enter a valid Google Group email address'
+          ui:hideError: true
+          default: 'google-group@broadinstitute.org'
   steps:
     - id: parsePackageFile
       name: Parse Spack Package File


### PR DESCRIPTION
after the 1.36.1 upgrade the error message that was supposed to display
for email address field validation broke,
which cause the template to hang
in that step
this fixes that issues

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
