### PR TITLE
fix(terraform-control-module): Do not require dev

### DIFF
--- a/backstage/templates/scaffolder/terraform-control-module/template.yaml
+++ b/backstage/templates/scaffolder/terraform-control-module/template.yaml
@@ -69,7 +69,6 @@ spec:
     - title: Terraform Configuration
       required:
         - gcpRegion
-        - gcpProjectDev
         - gcpProjectProd
         - gcsBucket
       properties:
@@ -83,7 +82,8 @@ spec:
         gcpProjectDev:
           title: Development GCP Project
           type: string
-          description: GCP project managed by the default/primary provider. Prod and Dev should use different projects.
+          description: >-
+            GCP project managed by the default/primary provider. A Dev project is *strongly encouraged* for most applications.
 
         gcpProjectProd:
           title: Production GCP Project


### PR DESCRIPTION
Some projects don't make sense to have a dev project. Added language to
make clear that it's still important to have one in 9/10 cases.
