### PR TITLE
fix(python-package): Pin poetry_core correctly

### DIFF
--- a/backstage/templates/scaffolder/python-package/content/pyproject.toml
+++ b/backstage/templates/scaffolder/python-package/content/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+requires = ["poetry_core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]


### PR DESCRIPTION
We updated to poetry 2 but left this out of date. Pinned an upper bound
as well to prevent the kerfuffle we had when poetry 2 came out.
