### PR TITLE
feat: add cost object as a field to create namespace template

### DIFF
--- a/backstage/packages/backend/package.json
+++ b/backstage/packages/backend/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/auto-instrumentations-node": "^0.57.1",
     "@opentelemetry/exporter-prometheus": "^0.200.0",
     "@opentelemetry/sdk-node": "^0.200.0",
-    "@pagerduty/backstage-plugin-backend": "^0.9.1",
+    "@pagerduty/backstage-plugin-backend": "0.9.5",
     "@roadiehq/scaffolder-backend-module-http-request": "^5.3.0",
     "@roadiehq/scaffolder-backend-module-utils": "^3.4.0",
     "@spotify/backstage-plugin-insights-backend": "^0.6.0",

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -23,6 +23,7 @@ spec:
         - namespace
         - teams
         - owners
+        - costobject
       properties:
         owners:
           title: 'GitHub Owners'
@@ -36,6 +37,11 @@ spec:
           type: string
           description: >-
             Namespace to create. Must be unique across the `bits-gke-clusters` Kubernetes environment.
+        costobject:
+          title: 'Cost Object'
+          type: string
+          description: >-
+            Broad Cost Object
         teams:
           title: 'Namespace Admins'
           type: array
@@ -63,6 +69,8 @@ spec:
           kind: Namespace
           metadata:
             name: ${{ parameters.namespace }}
+            labels:
+              costobject: ${{ parameters.costobject }}
 
     - id: writeNamespace
       name: Write Namespace YAML File

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -40,6 +40,7 @@ spec:
         costobject:
           title: 'Cost Object'
           type: string
+          pattern: '^\d+$'
           description: >-
             Broad Cost Object
         teams:

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -71,7 +71,7 @@ spec:
           metadata:
             name: ${{ parameters.namespace }}
             labels:
-              costobject: ${{ parameters.costobject }}
+              charge_to_costobject: ${{ parameters.costobject }}
 
     - id: writeNamespace
       name: Write Namespace YAML File

--- a/backstage/yarn.lock
+++ b/backstage/yarn.lock
@@ -14465,9 +14465,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-backend@npm:^0.9.1":
-  version: 0.9.4
-  resolution: "@pagerduty/backstage-plugin-backend@npm:0.9.4"
+"@pagerduty/backstage-plugin-backend@npm:0.9.5":
+  version: 0.9.5
+  resolution: "@pagerduty/backstage-plugin-backend@npm:0.9.5"
   dependencies:
     "@backstage/backend-common": "npm:^0.23.3"
     "@backstage/backend-defaults": "npm:^0.4.1"
@@ -14492,7 +14492,7 @@ __metadata:
     uuid: "npm:^9.0.1"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10c0/d726616455aeb05b8713b55c157614a97ad5cc4d8cfd150b1306d05e2d3ee71442d6553f05b63aac46539ee37b1942026afbb5e05f84b4a8b9ebc7500bcdfeaa
+  checksum: 10c0/e7620d701ee675567e35d92c8ded7a18856e5a6e68fb16943f877cfed3f10284cbbf002a6fb84faefff97e13921b3a0d7e18e24890dbbc7ebde94ad8d7915a4e
   languageName: node
   linkType: hard
 
@@ -23209,7 +23209,7 @@ __metadata:
     "@opentelemetry/auto-instrumentations-node": "npm:^0.57.1"
     "@opentelemetry/exporter-prometheus": "npm:^0.200.0"
     "@opentelemetry/sdk-node": "npm:^0.200.0"
-    "@pagerduty/backstage-plugin-backend": "npm:^0.9.1"
+    "@pagerduty/backstage-plugin-backend": "npm:0.9.5"
     "@roadiehq/scaffolder-backend-module-http-request": "npm:^5.3.0"
     "@roadiehq/scaffolder-backend-module-utils": "npm:^3.4.0"
     "@spotify/backstage-plugin-insights-backend": "npm:^0.6.0"


### PR DESCRIPTION
The kube create namespace template now takes cost object as an input
which sets that label, so that it can be uses in BQ to charge back
resource ussage to the owners
---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
