### PR TITLE
feat: Add Config Connector to Kube template

### DIFF
--- a/.cloudbuild/gke-deploy.yaml
+++ b/.cloudbuild/gke-deploy.yaml
@@ -18,7 +18,8 @@ steps:
       - 'fn'
       - 'render'
       - 'deployment/${_APP}'
-  # set environment=dev label
+
+  # set environment=>_ENV label
   - id: kpt-set-labels
     name: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:477.0.0-debian_component_based'
     args:
@@ -30,6 +31,18 @@ steps:
       - 'gcr.io/kpt-fn/set-labels:v0.2.0'
       - '--'
       - 'environment=${_ENV}'
+  # Set Branch env variable
+  - id: kpt-set-branch
+    name: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:477.0.0-debian_component_based'
+    args:
+      - 'kpt'
+      - 'fn'
+      - 'eval'
+      - 'deployment/${_APP}'
+      - '--image'
+      - 'gcr.io/kpt-fn/apply-setters:v0.2.0'
+      - '--'
+      - 'branch_name=${_BRANCH}'
 
   # # Set Image
   - id: kpt-set-image

--- a/.github/workflows/cloudbuild.yaml
+++ b/.github/workflows/cloudbuild.yaml
@@ -8,7 +8,7 @@ name: "Cloud Build"
       - 'backstage/**'
       - 'deployment/backstage/**'
       - '.cloudbuild/**'
-   
+
 # The below environment variables are used to set up the Cloud Build trigger
 # and can be changed from the defaults if the common build environment doesn't meet the needs of the service
 env:
@@ -81,5 +81,5 @@ jobs:
             --service-account='projects/${_BUILDER_PROJECT}/serviceAccounts/${_SERVICE_ACCOUNT}' \
             --config=.cloudbuild/gke-deploy.yaml \
             --region=us-east4 \
-            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${GITHUB_SHA},_BRANCH=${GITHUB_HEAD_REF}_ENV="dev" \
+            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${GITHUB_SHA},_BRANCH=${GITHUB_HEAD_REF},_ENV="dev" \
             --project=${_BUILDER_PROJECT}

--- a/.github/workflows/cloudbuild.yaml
+++ b/.github/workflows/cloudbuild.yaml
@@ -4,6 +4,11 @@ name: "Cloud Build"
   pull_request:
     branches:
       - main
+    paths:
+      - 'backstage/**'
+      - 'deployment/backstage/**'
+      - '.cloudbuild/**'
+   
 # The below environment variables are used to set up the Cloud Build trigger
 # and can be changed from the defaults if the common build environment doesn't meet the needs of the service
 env:
@@ -76,5 +81,5 @@ jobs:
             --service-account='projects/${_BUILDER_PROJECT}/serviceAccounts/${_SERVICE_ACCOUNT}' \
             --config=.cloudbuild/gke-deploy.yaml \
             --region=us-east4 \
-            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${GITHUB_SHA},_ENV="dev" \
+            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${GITHUB_SHA},_BRANCH=${GITHUB_HEAD_REF}_ENV="dev" \
             --project=${_BUILDER_PROJECT}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,5 +43,5 @@ jobs:
             --service-account='projects/${_BUILDER_PROJECT}/serviceAccounts/${_SERVICE_ACCOUNT}' \
             --config=.cloudbuild/gke-deploy.yaml \
             --region=us-east4 \
-            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${{ github.event.number }},_ENV="prod" \
+            --substitutions=_APP=${_APP},_REGISTRY_PROJECT=${_REGISTRY_PROJECT},_REGISTRY_NAME=${_REGISTRY_NAME},_BUILDER_PROJECT=${_BUILDER_PROJECT},_SERVICE_ACCOUNT=${_SERVICE_ACCOUNT},_IMAGE_TAG=${{ github.event.number }},_BRANCH="main",_ENV="prod" \
             --project=${_BUILDER_PROJECT}

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -9,7 +9,9 @@ metadata:
     In addition to the namespace, the PR will add permissions for the namespace
     to the team's Google Group. The namespace will also have the ability to use
     [Config Connector](https://cloud.google.com/config-connector/docs/overview)
-    to manage GCP resource directly from the kubernetes namespace. A Google Service Account
+    to manage GCP resource directly from the kubernetes namespace. This allows
+    users to define and manage GCP resources using Kubernetes manifests, providing
+    a unified and declarative approach to infrastructure management. A Google Service Account
     will be created for you, and when granted roles in your project can be used to manage GCP
     resources.
   tags:
@@ -61,8 +63,8 @@ spec:
           type: string
           description: >-
             The name of a GCP Project to associate with this namespace for use with
-            [Config Connector](https://cloud.google.com/config-connector/docs/how-to/getting-started)
-
+            [Config Connector](https://cloud.google.com/config-connector/docs/how-to/getting-started).
+            This project will be used by Config Connector to manage resources within the namespace.
   steps:
     - action: roadiehq:utils:serialize:yaml
       id: Namespace

--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -7,7 +7,11 @@ metadata:
   description: >-
     Create a new Pull Request to add a new namespace to the `bits-gke-clusters` Kubernetes environment.
     In addition to the namespace, the PR will add permissions for the namespace
-    to the team's Google Group.
+    to the team's Google Group. The namespace will also have the ability to use
+    [Config Connector](https://cloud.google.com/config-connector/docs/overview)
+    to manage GCP resource directly from the kubernetes namespace. A Google Service Account
+    will be created for you, and when granted roles in your project can be used to manage GCP
+    resources.
   tags:
     - recommended
     - kubernetes
@@ -18,7 +22,7 @@ spec:
   type: service
 
   parameters:
-    - title: Package Information
+    - title: Namespace Information
       required:
         - namespace
         - teams
@@ -52,6 +56,12 @@ spec:
             ui:help: 'Enter a valid Google Group email address'
             ui:hideError: true
             default: 'google-group@broadinstitute.org'
+        gcpProject:
+          title: 'Google Cloud Project'
+          type: string
+          description: >-
+            The name of a GCP Project to associate with this namespace for use with
+            [Config Connector](https://cloud.google.com/config-connector/docs/how-to/getting-started)
 
   steps:
     - action: roadiehq:utils:serialize:yaml
@@ -63,6 +73,8 @@ spec:
           kind: Namespace
           metadata:
             name: ${{ parameters.namespace }}
+            annotations:
+              cnrm.cloud.google.com/project-id: ${{ parameters.gcpProject }}
 
     - id: writeNamespace
       name: Write Namespace YAML File
@@ -102,6 +114,98 @@ spec:
       input:
         path: manifests/namespace/${{ parameters.namespace }}/namespace-admin.yaml
         content: ${{ steps.serializeRoleBinding.output.serialized }}
+
+    - action: roadiehq:utils:serialize:yaml
+      id: ConfigConnectorContext
+      name: Create Config Connector Context
+      input:
+        data:
+          apiVersion: core.cnrm.cloud.google.com/v1beta1
+          kind: ConfigConnectorContext
+          metadata:
+            # you can only have one ConfigConnectorContext per namespace
+            name: configconnectorcontext.core.cnrm.cloud.google.com
+            namespace: ${{ parameters.namespace}}
+          spec:
+            googleServiceAccount: "${{ parameters.namespace }}@bits-gke-clusters.iam.gserviceaccount.com"
+            stateIntoSpec: Absent
+
+    - id: writeConfigConnectorContext
+      name: Write Config Connector Context YAML File
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/${{ parameters.namespace }}/configconnectorcontext.yaml
+        content: ${{ steps.ConfigConnectorContext.output.serialized }}
+
+    - action: roadiehq:utils:serialize:yaml
+      id: IAMServiceAccount
+      name: Create IAMServiceAccount KRM file
+      input:
+        data:
+          apiVersion: iam.cnrm.cloud.google.com/v1beta1
+          kind: IAMServiceAccount
+          metadata:
+            namespace: mcp
+            name: ${{ parameters.namespace }}
+          spec:
+            description: >-
+              Managed Service Account create by Config Connector
+              In the MCP Namespace
+
+    - id: writeIAMServiceAccount
+      name: Write IAMServiceAccount YAML File into the MCP Namespace
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/mcp/serviceaccounts/${{ parameters.namespace }}/serviceaccount.yaml
+        content: ${{ steps.IAMServiceAccount.output.serialized }}
+
+    - action: roadiehq:utils:serialize:yaml
+      id: workloadIdentityUser
+      name: Create IAMPolicyMember token creator binding KRM file
+      input:
+        data:
+          apiVersion: iam.cnrm.cloud.google.com/v1beta1
+          kind: IAMPolicyMember
+          metadata:
+            namespace: mcp
+            name: ${{ parameters.namespace }}-workloadidentity-user
+          spec:
+            member: principal://iam.googleapis.com/projects/864716322442/locations/global/workloadIdentityPools/bits-gke-clusters.svc.id.goog/subject/ns/${{ parameters.namespace }}/sa/cnrm-system/cnrm-controller-manager
+            resourceRef:
+              kind: IAMServiceAccount
+              name: ${{ parameters.namespace }}
+            role: roles/iam.workloadIdentityUser
+
+    - id: writeWorkloadIdentityUser
+      name: Write IAMServiceAccount YAML File into the MCP Namespace
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/mcp/serviceaccounts/${{ parameters.namespace }}/workload-identity-user.yaml
+        content: ${{ steps.workloadIdentityUser.output.serialized }}
+
+    - action: roadiehq:utils:serialize:yaml
+      id: tokenCreator
+      name: Create IAMPolicyMember token creator binding KRM file
+      input:
+        data:
+          apiVersion: iam.cnrm.cloud.google.com/v1beta1
+          kind: IAMPolicyMember
+          metadata:
+            namespace: mcp
+            name: ${{ parameters.namespace }}-serviceaccount-tokencreator
+          spec:
+            member: serviceAccount:bits-gke-clusters.svc.id.goog[cnrm-system/cnrm-controller-manager-${{ parameters.namespace }}
+            resourceRef:
+              kind: IAMServiceAccount
+              name: ${{ parameters.namespace }}
+            role: roles/iam.serviceAccountTokenCreator
+
+    - id: writeTokenCreator
+      name: Write IAMServiceAccount YAML File into the MCP Namespace
+      action: roadiehq:utils:fs:write
+      input:
+        path: manifests/namespace/mcp/serviceaccounts/${{ parameters.namespace }}/serviceaccount-tokencreator.yaml
+        content: ${{ steps.tokenCreator.output.serialized }}
 
     - action: fetch:plain:file
       id: fetchFile


### PR DESCRIPTION
Adds the boiler place configs to enable KCC for new namespaces,
allowing users to create GCP resources from GKE

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
