### PR TITLE
fix: Add service account info to namespace template

### DIFF
--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -240,3 +240,15 @@ spec:
       - title: View the pull request on GitHub
         icon: github
         url: ${{ steps['createPullRequest'].output.remoteUrl }}
+    text:
+      - title: Google Service Account
+        content: |
+          ## Service Account Information
+
+          A service account has been created for your namespace with the email:
+
+          ${{ parameters.namespace }}@bits-gke-clusters.iam.gserviceaccount.com
+
+          You can use this service account to grant permissions in your GCP projects, allowing your
+          Kubernetes workloads to access GCP resources using Config Connector. To grant permissions,
+          add IAM roles to this service account in your target GCP projects.


### PR DESCRIPTION
adds an output providing the users the service account that will be
created upon merge.

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
