### PR TITLE
chore(templates): Add external flag

### DIFF
--- a/backstage/templates/scaffolder/add-repo/template.yaml
+++ b/backstage/templates/scaffolder/add-repo/template.yaml
@@ -12,6 +12,7 @@ metadata:
   tags:
     - recommended
     - production
+    - external
 
 spec:
   owner: group:devnull

--- a/backstage/templates/scaffolder/pr-with-catalog-entry/template.yaml
+++ b/backstage/templates/scaffolder/pr-with-catalog-entry/template.yaml
@@ -8,6 +8,7 @@ metadata:
   tags:
     - recommended
     - production
+    - external
 
 spec:
   owner: group:devnull

--- a/backstage/templates/scaffolder/terraform-cloud-run/template.yaml
+++ b/backstage/templates/scaffolder/terraform-cloud-run/template.yaml
@@ -12,6 +12,7 @@ metadata:
     - terraform
     - gcp
     - production
+    - external
 
 spec:
   owner: group:devnull

--- a/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
+++ b/backstage/templates/scaffolder/terraform-storage-transfer/template.yaml
@@ -12,6 +12,7 @@ metadata:
     - terraform
     - gcp
     - production
+    - external
 
 spec:
   owner: group:devnull


### PR DESCRIPTION
I want to mark templates that we intend for a non-BITS audience so that
I can easily link to them all at once from our ServiceNow directory
page.
