### PR TITLE
feat: Add http soundcheck collector token

### DIFF
--- a/backstage/app-config.local.example.yaml
+++ b/backstage/app-config.local.example.yaml
@@ -126,6 +126,11 @@ soundcheck:
     token: "${SOUNDCHECK_SLACK_BOT_TOKEN}"
     appToken: "${SOUNDCHECK_SLACK_APP_TOKEN}"
     signingSecret: "${SOUNDCHECK_SLACK_SIGNING_SECRET}"
+  collectors:
+    http:
+      secrets:
+        - key: githubApiToken
+          value: ${GH_PAM_TOKEN}
 
 permission:
   enabled: true

--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -250,6 +250,12 @@ soundcheck:
       $file: ./secrets/backstage-soundcheck-slack-app-token
     signingSecret:
       $file: ./secrets/backstage-soundcheck-slack-signing-secret
+  collectors:
+    http:
+      secrets:
+        - key: githubApiToken
+          value:
+            $file: ./secrets/backstage-soundcheck-http-collector-token
 
 permission:
   enabled: true

--- a/backstage/secrets/backstage-soundcheck-http-collector-token
+++ b/backstage/secrets/backstage-soundcheck-http-collector-token
@@ -1,0 +1,1 @@
+not-a-real-secret

--- a/deployment/dev/Kptfile
+++ b/deployment/dev/Kptfile
@@ -59,6 +59,8 @@ pipeline:
             path: "backstage-soundcheck-slack-app-token"
           - resourceName: "projects/bits-backstage-dev/secrets/backstage-soundcheck-slack-signing-secret/versions/latest"
             path: "backstage-soundcheck-slack-signing-secret"
+          - resourceName: "projects/bits-backstage-dev/secrets/backstage-soundcheck-http-collector-token/versions/latest"
+            path: "backstage-soundcheck-http-collector-token"
 
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4
       configMap:

--- a/deployment/dev/terraform/terraform.tfvars
+++ b/deployment/dev/terraform/terraform.tfvars
@@ -69,6 +69,10 @@ google_secret_manager_secrets = {
     service = "backstage"
     type    = "string"
   },
+  backstage-soundcheck-http-collector-token = {
+    service = "backstage"
+    type    = "string"
+  },
 }
 
 additional_databases = [

--- a/deployment/prod/Kptfile
+++ b/deployment/prod/Kptfile
@@ -59,6 +59,8 @@ pipeline:
             path: "backstage-soundcheck-slack-app-token"
           - resourceName: "projects/bits-backstage-prod/secrets/backstage-soundcheck-slack-signing-secret/versions/latest"
             path: "backstage-soundcheck-slack-signing-secret"
+          - resourceName: "projects/bits-backstage-prod/secrets/backstage-soundcheck-http-collector-token/versions/latest"
+            path: "backstage-soundcheck-http-collector-token"
 
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4
       configMap:

--- a/deployment/prod/terraform/terraform.tfvars
+++ b/deployment/prod/terraform/terraform.tfvars
@@ -70,6 +70,10 @@ google_secret_manager_secrets = {
     service = "backstage"
     type    = "string"
   },
+  backstage-soundcheck-http-collector-token = {
+    service = "backstage"
+    type    = "string"
+  },
 }
 additional_databases = [
   { name      = "backstage_plugin_app",


### PR DESCRIPTION
This will allows for authentication to the GitHub API for soundcheck
http checks. Our first use case is to check for
conventional release labels

---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
