### PR TITLE
fix(template): Correct syntax for service account member reference

### DIFF
--- a/backstage/templates/scaffolder/add-namespace/template.yaml
+++ b/backstage/templates/scaffolder/add-namespace/template.yaml
@@ -195,7 +195,7 @@ spec:
             namespace: mcp
             name: ${{ parameters.namespace }}-serviceaccount-tokencreator
           spec:
-            member: serviceAccount:bits-gke-clusters.svc.id.goog[cnrm-system/cnrm-controller-manager-${{ parameters.namespace }}
+            member: serviceAccount:bits-gke-clusters.svc.id.goog[cnrm-system/cnrm-controller-manager-${{ parameters.namespace }}]
             resourceRef:
               kind: IAMServiceAccount
               name: ${{ parameters.namespace }}


### PR DESCRIPTION
typo in the template
discovered in https://github.com/broadinstitute/kubernetes-configs/pull/39
---

## Write Good Commit Messages

[The seven rules of a great Git commit message](https://cbea.ms/git-commit/)

* Separate subject from body with a blank line
* Limit the subject line to 50 characters
* Capitalize the subject line
* Do not end the subject line with a period
* Use the imperative mood in the subject line
* Wrap the body at 72 characters
* Use the body to explain what and why vs. how
