### PR TITLE
feat: Add Header and SupportButton to HomePage component

### DIFF
--- a/backstage/packages/app/src/components/home/HomePage.tsx
+++ b/backstage/packages/app/src/components/home/HomePage.tsx
@@ -96,10 +96,10 @@ const useStyles = makeStyles(theme => ({
     },
     supportButton: {
         '& button': {
-            color: '#ffffff',
-            backgroundColor: '#1976d2',
+            color: theme.palette.common.white,
+            backgroundColor: theme.palette.primary.main,
             '&:hover': {
-                backgroundColor: '#1565c0',
+                backgroundColor: theme.palette.primary.dark,
             },
         },
     },

--- a/backstage/packages/app/src/components/home/HomePage.tsx
+++ b/backstage/packages/app/src/components/home/HomePage.tsx
@@ -29,7 +29,9 @@ import {
     GitHubIcon,
     HelpIcon,
     DashboardIcon,
+    Header,
 } from '@backstage/core-components';
+import { Box } from '@material-ui/core';
 import {
     starredEntitiesApiRef,
     entityRouteRef,
@@ -45,6 +47,7 @@ import {
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ComponentType, PropsWithChildren } from 'react';
+import { SupportButton } from '@backstage/core-components';
 
 export default {
     title: 'Backstage Home Page',
@@ -91,6 +94,15 @@ const useStyles = makeStyles(theme => ({
     searchBarOutline: {
         borderStyle: 'none',
     },
+    supportButton: {
+        '& button': {
+            color: '#ffffff',
+            backgroundColor: '#1976d2',
+            '&:hover': {
+                backgroundColor: '#1565c0',
+            },
+        },
+    },
 }));
 
 const useLogoStyles = makeStyles(theme => ({
@@ -113,6 +125,11 @@ export const HomePage = () => {
     return (
         <SearchContextProvider>
             <Page themeId="home">
+                <Header title="Welcome to Backstage" pageTitleOverride="Home">
+                    <Box className={classes.supportButton}>
+                        <SupportButton />
+                    </Box>
+                </Header>
                 <Content>
                     <Grid container justifyContent="center" spacing={6}>
                         <HomePageCompanyLogo


### PR DESCRIPTION
This adds a the same support button that appears on the [/catalog](https://backstage.broadinstitute.org/catalog) page to the home page. It currently provides a pop up (image to be attached) that links to GitHub issues for the repo, a slack channel, and a link to the service now "create a ticket" form. 

![Screenshot 2025-06-20 at 1 24 32 PM](https://github.com/user-attachments/assets/6344c24e-e652-4b25-9628-b63578613d87)
