### PR TITLE
feat: add allowed iframe host for sanitizer in techdocs configuration

### DIFF
--- a/backstage/app-config.production.yaml
+++ b/backstage/app-config.production.yaml
@@ -46,6 +46,10 @@ techdocs:
     type: 'googleGcs'
     googleGcs:
       bucketName: ${TECHDOCS_STORAGE_BUCKET}
+  sanitizer:
+    allowedIframeHosts:
+      - broadinstitute.org
+
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   environment: ${NODE_ENV}


### PR DESCRIPTION
This allows iframes from the Broad to be embedded in our techdocs 