### PR TITLE
fix: Fixing the GKE PDB Error

### DIFF
--- a/deployment/backstage/backstage.yaml
+++ b/deployment/backstage/backstage.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: gcp-cloud-build-deploy
     backstage.io/kubernetes-id: backstage
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: backstage

--- a/deployment/backstage/backstage.yaml
+++ b/deployment/backstage/backstage.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: gcp-cloud-build-deploy
     backstage.io/kubernetes-id: backstage
 spec:
-  replicas: 2
+  replicas: 2 # kpt-set: ${min_replicas}
   selector:
     matchLabels:
       app: backstage


### PR DESCRIPTION
Fixing the GKE PDB Error  : 

"A Pod Disruption Budget exists that allows for 0 Pod evictions. A Pod Disruption Budget must allow for at least 1 Pod eviction so that GKE can perform maintenance."
