### PR TITLE
feat: Add AWS, GCP, and GitHub system configurations to Backstage

### DIFF
--- a/backstage/templates/BITS/systems/aws.yaml
+++ b/backstage/templates/BITS/systems/aws.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: aws
+  description: |
+    Amazon Web Services (AWS) 
+  title: "Amazon Web Services"
+  tags:
+  - aws
+  - cloud
+  annotations:
+    backstage.io/managed-by: backstage
+spec:
+  owner: devnull
+  domain: paas
+  lifecycle: production

--- a/backstage/templates/BITS/systems/gcp.yaml
+++ b/backstage/templates/BITS/systems/gcp.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: gcp
+  description: |
+    Google Cloud Platform (GCP) is Broad Institute's primary cloud provider.
+    It hosts a variety of Broad services and platforms.
+  title: "Google Cloud Platform"
+  tags:
+  - gcp
+  - cloud
+  annotations:
+    backstage.io/managed-by: backstage
+spec:
+  owner: devnull
+  domain: paas
+  lifecycle: production

--- a/backstage/templates/BITS/systems/github.yaml
+++ b/backstage/templates/BITS/systems/github.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: github
+  description: |
+    Broad Institute's GitHub systems, including both the main
+    organization and the development organization.
+
+  title: "GitHub"
+  links:
+    - url: "https://github.com/"
+      title: "GitHub"
+      icon: github
+    - url: "https://github.com/broadinstitute"
+      title: "Broad GitHub Organization"
+      icon: github
+    - url: "https://github.com/broadinstitute-dev"
+      title: "Broad GitHub Dev Organization"
+      icon: github
+    - url: "https://github.com/enterprises/broadinstitute"
+      title: "Broad GitHub Enterprise"
+      icon: github
+  tags:
+  - github
+  annotations:
+    backstage.io/managed-by: backstage
+spec:
+  owner: devnull
+  domain: paas
+  lifecycle: production


### PR DESCRIPTION
This way we can connect some of our services, like the upcoming AWS landing zone accelerator, to a system