### PR TITLE
feat: add GCP Billing Account Picker field extension with tests and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ dist
 # Custom ignores
 *.expanded.yaml
 .backstage-tmp
+mise.local.toml

--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import { SelectFieldFromApiExtension } from '@roadiehq/plugin-scaffolder-fronten
 import { GithubTeamPickerExtension } from './scaffolder/GithubTeamPicker/GithubTeamPicker';
 import { GoogleAccessTokenFieldExtension } from './scaffolder/GoogleAccessTokenFieldExtension';
 import { GcpResourcePickerExtension } from './scaffolder/GcpResourcePicker';
+import { GcpBillingAccountPickerExtension } from './scaffolder/GcpBillingAccountPicker';
 import skillExchangePlugin from '@spotify/backstage-plugin-skill-exchange/alpha';
 import soundcheckPlugin from '@spotify/backstage-plugin-soundcheck/alpha';
 import { HomePage } from './components/home/HomePage';
@@ -152,6 +153,7 @@ const scaffolderModuleOverrides = createFrontendModule({
                             <GithubTeamPickerExtension />
                             <GoogleAccessTokenFieldExtension />
                             <GcpResourcePickerExtension />
+                            <GcpBillingAccountPickerExtension />
                         </ScaffolderFieldExtensions>
                     </ScaffolderPage>
                 ),

--- a/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/GcpBillingAccountPicker.test.tsx
+++ b/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/GcpBillingAccountPicker.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestApiProvider } from '@backstage/test-utils';
+import {
+  ErrorApi,
+  errorApiRef,
+  googleAuthApiRef,
+} from '@backstage/core-plugin-api';
+import { GcpBillingAccountPicker } from './GcpBillingAccountPicker';
+import { GcpBillingAccountPickerProps } from './schema';
+
+/**
+ * The picker talks to the Cloud Billing `billingAccounts.list` endpoint
+ * directly via `fetch`, using a user access token from the Google auth API.
+ * The tests mock both that API and `fetch`, then assert on the requests the
+ * component builds and on how it reflects results / the stored value.
+ */
+describe('<GcpBillingAccountPicker />', () => {
+  const onChange = jest.fn();
+  const getAccessToken = jest.fn(async () => 'fake-token');
+  const mockGoogleAuth = { getAccessToken };
+  const mockErrorApi: jest.Mocked<ErrorApi> = {
+    post: jest.fn(),
+    error$: jest.fn(),
+  };
+  const fetchMock = jest.fn();
+  const originalFetch = global.fetch;
+
+  const okJson = (body: unknown) => ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+
+  const account = (over: Record<string, unknown> = {}) => ({
+    name: 'billingAccounts/000000-111111-222222',
+    displayName: 'My Billing Account',
+    open: true,
+    ...over,
+  });
+
+  const renderPicker = (overrides: Record<string, unknown> = {}) =>
+    render(
+      <TestApiProvider
+        apis={[
+          [googleAuthApiRef, mockGoogleAuth],
+          [errorApiRef, mockErrorApi],
+        ]}
+      >
+        <GcpBillingAccountPicker
+          {...({
+            onChange,
+            required: false,
+            rawErrors: [],
+            schema: {},
+            uiSchema: {},
+            ...overrides,
+          } as unknown as GcpBillingAccountPickerProps)}
+        />
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    onChange.mockClear();
+    getAccessToken.mockClear();
+    mockErrorApi.post.mockClear();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(okJson({ billingAccounts: [] }));
+    (global as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  it('lists billing accounts on mount', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        billingAccounts: [
+          account(),
+          account({
+            name: 'billingAccounts/333333-444444-555555',
+            displayName: 'Another Account',
+          }),
+        ],
+      }),
+    );
+
+    renderPicker();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toContain('/billingAccounts?');
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await waitFor(() => {
+      expect(screen.getByText('My Billing Account')).toBeInTheDocument();
+      expect(screen.getByText('Another Account')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a loading spinner while the account list is being fetched', async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise(resolve => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderPicker();
+
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar')).toBeInTheDocument(),
+    );
+
+    resolveFetch(okJson({ billingAccounts: [account()] }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('follows pagination to collect every page', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okJson({
+          billingAccounts: [account()],
+          nextPageToken: 'page-2',
+        }),
+      )
+      .mockResolvedValueOnce(
+        okJson({
+          billingAccounts: [
+            account({
+              name: 'billingAccounts/333333-444444-555555',
+              displayName: 'Another Account',
+            }),
+          ],
+        }),
+      );
+
+    renderPicker();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toContain('pageToken=page-2');
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await waitFor(() => {
+      expect(screen.getByText('My Billing Account')).toBeInTheDocument();
+      expect(screen.getByText('Another Account')).toBeInTheDocument();
+    });
+  });
+
+  it('reports an error instead of silently truncating when the account list never ends', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({ billingAccounts: [account()], nextPageToken: 'more' }),
+    );
+
+    renderPicker();
+
+    await waitFor(() => expect(mockErrorApi.post).toHaveBeenCalled());
+    expect(mockErrorApi.post.mock.calls[0][0].message).toMatch(
+      /refusing to silently truncate/,
+    );
+
+    await userEvent.click(screen.getByRole('textbox'));
+    expect(screen.queryByText('My Billing Account')).not.toBeInTheDocument();
+  });
+
+  it('scopes the list to a parent when configured', async () => {
+    renderPicker({
+      uiSchema: {
+        'ui:options': { parent: 'billingAccounts/000000-111111-222222' },
+      },
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(new URL(url).searchParams.get('filter')).toBe(
+      'subaccountParent=billingAccounts/000000-111111-222222',
+    );
+  });
+
+  it('excludes closed accounts when openOnly is set', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        billingAccounts: [
+          account(),
+          account({
+            name: 'billingAccounts/333333-444444-555555',
+            displayName: 'Closed Account',
+            open: false,
+          }),
+        ],
+      }),
+    );
+
+    renderPicker({ uiSchema: { 'ui:options': { openOnly: true } } });
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await waitFor(() =>
+      expect(screen.getByText('My Billing Account')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Closed Account')).not.toBeInTheDocument();
+  });
+
+  it('writes the short account id back to the form by default', async () => {
+    fetchMock.mockResolvedValue(okJson({ billingAccounts: [account()] }));
+
+    renderPicker();
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(await screen.findByText('My Billing Account'));
+
+    expect(onChange).toHaveBeenCalledWith('000000-111111-222222');
+  });
+
+  it('writes the resource name when outputFormat is resourceName', async () => {
+    fetchMock.mockResolvedValue(okJson({ billingAccounts: [account()] }));
+
+    renderPicker({
+      uiSchema: { 'ui:options': { outputFormat: 'resourceName' } },
+    });
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(await screen.findByText('My Billing Account'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      'billingAccounts/000000-111111-222222',
+    );
+  });
+
+  it('shows the account id in the closed field', async () => {
+    fetchMock.mockResolvedValue(okJson({ billingAccounts: [account()] }));
+
+    renderPicker({ formData: '000000-111111-222222' });
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await waitFor(() =>
+      expect(input.value).toBe('000000-111111-222222'),
+    );
+  });
+
+  it('falls back to a placeholder showing the stored value when it matches no loaded account', async () => {
+    // e.g. the user lost access to the account, or `parent`/`openOnly`
+    // filtered it out — the account list never contains a matching value.
+    fetchMock.mockResolvedValue(
+      okJson({
+        billingAccounts: [
+          account({
+            name: 'billingAccounts/333333-444444-555555',
+            displayName: 'Another Account',
+          }),
+        ],
+      }),
+    );
+
+    renderPicker({ formData: '000000-111111-222222' });
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await waitFor(() =>
+      expect(input.value).toBe('000000-111111-222222'),
+    );
+    // Confirm it isn't just showing pre-load state, but has actually settled
+    // after the (non-matching) account list finished loading.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(input.value).toBe('000000-111111-222222');
+  });
+
+  it('reports an error when the list request fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+      text: async () => 'forbidden',
+    });
+
+    renderPicker();
+
+    await waitFor(() => expect(mockErrorApi.post).toHaveBeenCalled());
+  });
+});

--- a/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/GcpBillingAccountPicker.tsx
+++ b/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/GcpBillingAccountPicker.tsx
@@ -1,0 +1,325 @@
+/*
+ * --------------------------------------------------------------------------
+ * Custom Scaffolder field extension that lets the signed-in user pick a
+ * Google Cloud Billing account they have access to — the same set of
+ * accounts they'd see listed at https://console.cloud.google.com/billing —
+ * authenticating to the Cloud Billing API with the user's own Google OAuth
+ * credentials.
+ *
+ * Unlike the Resource Manager `:search` endpoints used by
+ * `GcpResourcePicker`, the Cloud Billing API's `billingAccounts.list` has no
+ * free-text query support. So this field lists every billing account the
+ * user can see once (following pagination), then filters client-side as the
+ * user types. If a user can see more accounts than the pagination cap
+ * allows, the field surfaces an error rather than silently hiding accounts
+ * — use `ui:options.parent` to scope the list to a specific billing
+ * account's sub-accounts instead.
+ *
+ * The closed field displays the billing account id, with the account's
+ * display name available as a hover tooltip; the open dropdown shows both
+ * the display name and id for each option, mirroring the "Account name" /
+ * "ID" columns on the Cloud Billing console.
+ *
+ * Drop it into your Backstage app (typically
+ * `packages/app/src/scaffolder/GcpBillingAccountPicker/`) and register it as
+ * shown in `extensions.ts`. Reference it from a template via
+ * `ui:field: GcpBillingAccountPicker`.
+ * --------------------------------------------------------------------------
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  useApi,
+  googleAuthApiRef,
+  errorApiRef,
+} from '@backstage/core-plugin-api';
+import {
+  TextField,
+  FormControl,
+  Tooltip,
+  CircularProgress,
+} from '@material-ui/core';
+import { Autocomplete, createFilterOptions } from '@material-ui/lab';
+import { GcpBillingAccountPickerProps } from './schema';
+
+/**
+ * Default OAuth scope used to acquire the user's Google access token. The
+ * read-only Cloud Billing scope is sufficient to list billing accounts.
+ * Whatever scope is requested here must also be listed under the Google
+ * auth provider's `additionalScopes` in app-config so the session covers
+ * it.
+ */
+const DEFAULT_SCOPES = [
+  'https://www.googleapis.com/auth/cloud-billing.readonly',
+];
+
+/** How many accounts to request per page. */
+const PAGE_SIZE = 100;
+
+/**
+ * Cap on how many pages to fetch before giving up. This is not a silent
+ * truncation limit — if the account list is still incomplete after this
+ * many pages, `listBillingAccounts` throws rather than returning a partial
+ * list, since a partial list would hide real accounts from the picker
+ * without any indication that's happening.
+ */
+const MAX_PAGES = 20;
+
+const BILLING_BASE = 'https://cloudbilling.googleapis.com/v1';
+
+export type GcpBillingAccountOutputFormat = 'id' | 'resourceName';
+
+type RawBillingAccount = {
+  name?: string;
+  displayName?: string;
+  open?: boolean;
+};
+
+type BillingAccountOption = {
+  /** Resource name, e.g. `billingAccounts/013939-8DE5F0-6BF33F`. */
+  name: string;
+  /** Short id, e.g. `013939-8DE5F0-6BF33F`. */
+  accountId: string;
+  /** Human-readable display name, e.g. "My Team's Billing Account". */
+  displayName: string;
+  /** Whether the account is still open (accepting new charges/links). */
+  open: boolean;
+  /** The value written back to the template, per `outputFormat`. */
+  value: string;
+};
+
+/**
+ * Fetch every billing account the caller can see, following pagination.
+ * `billingAccounts.list` has no text-search filter — only `subaccountParent`
+ * — so the full (bounded) result set is fetched up front and filtered
+ * client-side by the picker.
+ */
+const listBillingAccounts = async (
+  token: string,
+  parent: string | undefined,
+  signal: AbortSignal,
+): Promise<RawBillingAccount[]> => {
+  const accounts: RawBillingAccount[] = [];
+  let pageToken: string | undefined;
+  let pages = 0;
+  do {
+    const params = new URLSearchParams({ pageSize: String(PAGE_SIZE) });
+    if (parent) {
+      params.set('filter', `subaccountParent=${parent}`);
+    }
+    if (pageToken) {
+      params.set('pageToken', pageToken);
+    }
+    const res = await fetch(
+      `${BILLING_BASE}/billingAccounts?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` }, signal },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `Cloud Billing billingAccounts.list failed (${res.status}): ${await res
+          .text()
+          .catch(() => '')}`,
+      );
+    }
+    const body = (await res.json()) as {
+      billingAccounts?: RawBillingAccount[];
+      nextPageToken?: string;
+    };
+    accounts.push(...(body.billingAccounts ?? []));
+    pageToken = body.nextPageToken;
+    pages += 1;
+  } while (pageToken && pages < MAX_PAGES);
+  if (pageToken) {
+    throw new Error(
+      `Cloud Billing billingAccounts.list has more than ${
+        MAX_PAGES * PAGE_SIZE
+      } accounts visible to this user; refusing to silently truncate the list. Use ui:options.parent to restrict the picker to a specific billing account's sub-accounts.`,
+    );
+  }
+  return accounts;
+};
+
+const formatValue = (
+  accountId: string,
+  name: string,
+  outputFormat: GcpBillingAccountOutputFormat,
+): string => (outputFormat === 'resourceName' ? name : accountId);
+
+/** Filter typed input against both the display name and the account id. */
+const filterOptions = createFilterOptions<BillingAccountOption>({
+  stringify: option => `${option.displayName} ${option.accountId}`,
+});
+
+/**
+ * Field component: a searchable picker for Google Cloud Billing accounts
+ * the signed-in user has access to, e.g. for passing as a `billingAccount`
+ * input to a project-creation action.
+ */
+export const GcpBillingAccountPicker = (
+  props: GcpBillingAccountPickerProps,
+) => {
+  const {
+    onChange,
+    rawErrors,
+    required,
+    formData,
+    schema: { title, description },
+    uiSchema,
+  } = props;
+
+  const googleAuth = useApi(googleAuthApiRef);
+  const errorApi = useApi(errorApiRef);
+
+  const options = uiSchema?.['ui:options'];
+  const outputFormat: GcpBillingAccountOutputFormat =
+    options?.outputFormat ?? 'id';
+  const openOnly = options?.openOnly ?? false;
+  const parent = options?.parent;
+  const scopes = options?.scopes ?? DEFAULT_SCOPES;
+
+  const [accounts, setAccounts] = useState<BillingAccountOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<BillingAccountOption | null>(null);
+
+  // Load the full list of accessible billing accounts once (and whenever the
+  // relevant config changes) rather than per-keystroke, since the API has no
+  // server-side text search to debounce against.
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    setLoading(true);
+    (async () => {
+      try {
+        const token = await googleAuth.getAccessToken(scopes);
+        const raw = await listBillingAccounts(token, parent, signal);
+        if (signal.aborted) return;
+        const mapped = raw
+          .filter((account): account is RawBillingAccount & { name: string } =>
+            Boolean(account.name),
+          )
+          .filter(account => !openOnly || account.open !== false)
+          .map(account => {
+            const accountId = account.name.replace(/^billingAccounts\//, '');
+            const displayName = account.displayName ?? accountId;
+            return {
+              name: account.name,
+              accountId,
+              displayName,
+              open: account.open ?? true,
+              value: formatValue(accountId, account.name, outputFormat),
+            };
+          })
+          .sort((a, b) => a.displayName.localeCompare(b.displayName));
+        setAccounts(mapped);
+      } catch (e) {
+        if (!signal.aborted) {
+          errorApi.post(e as Error);
+          setAccounts([]);
+        }
+      } finally {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [parent, openOnly, outputFormat, scopes, googleAuth, errorApi]);
+
+  // Keep the displayed selection in sync with the field's stored value. The
+  // form may seed `formData` (a configured default, or a value restored when
+  // the user navigates back to this step) before the account list has
+  // loaded — or the value may never resolve at all, e.g. the user lost
+  // access to that account, `parent`/`openOnly` changed, or the account list
+  // was too large to fully load. Prefer a fully-labelled match from the
+  // loaded accounts; otherwise fall back to a placeholder built from the raw
+  // value so the stored value still shows instead of rendering blank. An
+  // existing placeholder for the same value is reused so we don't downgrade
+  // a richer selection on every render.
+  useEffect(() => {
+    setSelected(prev => {
+      if (!formData) {
+        return prev ? null : prev;
+      }
+      const match = accounts.find(account => account.value === formData);
+      if (match) {
+        return match;
+      }
+      if (prev?.value === formData) {
+        return prev;
+      }
+      return {
+        name: formData,
+        accountId: formData,
+        displayName: formData,
+        open: true,
+        value: formData,
+      };
+    });
+  }, [formData, accounts]);
+
+  const updateChange = (
+    _: React.ChangeEvent<{}>,
+    option: BillingAccountOption | null,
+  ) => {
+    onChange(option?.value ?? '');
+  };
+
+  return (
+    <FormControl
+      margin="normal"
+      required={required}
+      error={rawErrors?.length > 0}
+    >
+      <Autocomplete
+        id="GcpBillingAccountPicker"
+        options={accounts}
+        value={selected}
+        loading={loading}
+        onChange={updateChange}
+        getOptionLabel={option => option.accountId}
+        getOptionSelected={(option, val) => option.value === val.value}
+        filterOptions={filterOptions}
+        renderOption={option => (
+          <div>
+            <div>{option.displayName}</div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>
+              {option.accountId}
+              {!option.open && ' (closed)'}
+            </div>
+          </div>
+        )}
+        loadingText="Loading billing accounts…"
+        noOptionsText="No billing accounts found"
+        renderInput={params => (
+          <Tooltip
+            title={selected?.displayName ?? ''}
+            disableHoverListener={!selected}
+          >
+            <TextField
+              {...params}
+              label={title ?? 'Billing Account'}
+              margin="dense"
+              required={required}
+              helperText={description}
+              variant="outlined"
+              FormHelperTextProps={{
+                margin: 'dense',
+                style: { marginLeft: 0 },
+              }}
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {loading ? (
+                      <CircularProgress color="inherit" size={16} />
+                    ) : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          </Tooltip>
+        )}
+      />
+    </FormControl>
+  );
+};

--- a/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/extensions.ts
+++ b/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/extensions.ts
@@ -1,0 +1,19 @@
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { GcpBillingAccountPicker } from './GcpBillingAccountPicker';
+import { GcpBillingAccountPickerSchema } from './schema';
+
+/**
+ * Register the field extension with the Scaffolder plugin.
+ * Referenced from a template via `ui:field: GcpBillingAccountPicker`.
+ *
+ * Passing `schema` lets the field appear in the Custom Field Explorer and
+ * powers validation/preview in the template editor.
+ */
+export const GcpBillingAccountPickerExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'GcpBillingAccountPicker',
+    component: GcpBillingAccountPicker,
+    schema: GcpBillingAccountPickerSchema,
+  }),
+);

--- a/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/index.ts
+++ b/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/index.ts
@@ -1,0 +1,1 @@
+export { GcpBillingAccountPickerExtension } from './extensions';

--- a/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/schema.ts
+++ b/backstage/packages/app/src/scaffolder/GcpBillingAccountPicker/schema.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod/v3';
+import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';
+
+/**
+ * Schema for the GcpBillingAccountPicker field extension. Generating it via
+ * `makeFieldSchema` produces both the JSON schema (consumed by the Custom
+ * Field Explorer / template editor preview) and the matching TypeScript
+ * types, so the two never drift apart.
+ *
+ * @see https://backstage.io/docs/features/software-templates/writing-custom-field-extensions/#previewing-custom-field-extensions
+ */
+const output = (zImpl: typeof z) => zImpl.string();
+
+const uiOptions = (zImpl: typeof z) =>
+  zImpl.object({
+    outputFormat: zImpl
+      .enum(['id', 'resourceName'])
+      .optional()
+      .describe(
+        'Shape of the value written to the template. "id" (default) emits the short billing account id (e.g. 013939-8DE5F0-6BF33F); "resourceName" emits the canonical resource name (e.g. billingAccounts/013939-8DE5F0-6BF33F).',
+      ),
+    openOnly: zImpl
+      .boolean()
+      .optional()
+      .describe(
+        'When true, only list billing accounts that are still open (excludes closed/disabled accounts). Defaults to false.',
+      ),
+    parent: zImpl
+      .string()
+      .optional()
+      .describe(
+        'Optional parent billing account to scope the list to its sub-accounts, e.g. "billingAccounts/013939-8DE5F0-6BF33F". Omit to list top-level accounts the user has access to.',
+      ),
+    scopes: zImpl
+      .array(zImpl.string())
+      .optional()
+      .describe(
+        'Override the requested Google OAuth scopes used to acquire the user access token.',
+      ),
+  });
+
+export const GcpBillingAccountPickerFieldSchema = makeFieldSchema({
+  output,
+  uiOptions,
+});
+
+/**
+ * UI options for the GcpBillingAccountPicker.
+ * @public
+ */
+export type GcpBillingAccountPickerUiOptions =
+  typeof GcpBillingAccountPickerFieldSchema.uiOptionsType;
+
+/**
+ * Props for the GcpBillingAccountPicker.
+ * @public
+ */
+export type GcpBillingAccountPickerProps =
+  typeof GcpBillingAccountPickerFieldSchema.type;
+
+/**
+ * JSON schema for the GcpBillingAccountPicker. Passed to
+ * `createScaffolderFieldExtension` so the field appears in the Custom Field
+ * Explorer.
+ * @public
+ */
+export const GcpBillingAccountPickerSchema =
+  GcpBillingAccountPickerFieldSchema.schema;

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -135,3 +135,185 @@ parameters:
               required:
                 - lastName
 ```
+
+## Custom Field Extensions
+
+Besides Roadie's
+[picker from API source](https://roadie.io/docs/scaffolder/scaffolder-parameters/#picker-from-external-api-source),
+we maintain two custom Scaffolder field extensions for working with GCP, adapted
+from the patterns in
+[datolabs-io/backstage-plugins](https://github.com/datolabs-io/backstage-plugins).
+Both live under `packages/app/src/scaffolder/` and are registered in
+`packages/app/src/App.tsx`. They rely on the `additionalScopes` already
+configured for the `google` auth provider in `app-config.production.yaml`
+(`https://www.googleapis.com/auth/cloud-platform`), which is why they only work
+for users who sign in with Google.
+
+They are commonly used together: `GcpResourcePicker` lets the user pick a
+project or folder, and `GoogleAccessToken` forwards that same user's credentials
+to a backend action so it can act on GCP as them instead of as a service
+account.
+
+### GoogleAccessToken
+
+`ui:field: GoogleAccessToken` renders nothing in the form. Instead it silently
+fetches the signed-in user's Google OAuth access token and puts it into the
+Scaffolder task's secrets under `googleAccessToken` (not into `parameters`, so
+it is never persisted to the template's stored values). Later steps can read it
+as `${{ secrets.googleAccessToken }}`, which is useful for any backend action
+that needs to call GCP as the requesting user rather than as a shared service
+account.
+
+Add it as a hidden field so it doesn't show a widget:
+
+```yaml
+parameters:
+  - title: Authenticate to GCP
+    properties:
+      googleAccessToken:
+        type: string
+        ui:field: GoogleAccessToken
+        ui:widget: hidden
+```
+
+Then use the secret in a later step:
+
+```yaml
+steps:
+  - id: gcp-action
+    name: Do something in GCP
+    action: gcp:some-action
+    input:
+      token: ${{ secrets.googleAccessToken }}
+```
+
+By default it requests the `cloud-platform` scope. You can narrow this with
+`ui:options.scopes`, as long as the scope is also listed under the `google`
+provider's `additionalScopes`:
+
+```yaml
+ui:options:
+  scopes:
+    - https://www.googleapis.com/auth/cloud-platform.read-only
+```
+
+### GcpResourcePicker
+
+`ui:field: GcpResourcePicker` renders a search-as-you-type autocomplete for
+picking a GCP project or folder the signed-in user has access to, backed by the
+Cloud Resource Manager `:search` API called with the user's own credentials (so
+results are naturally scoped to what they can see). Because this field also
+ships a schema, it shows up in Backstage's
+[Custom Field Explorer](https://backstage.io/docs/features/software-templates/writing-custom-field-extensions/#previewing-custom-field-extensions)
+for interactive testing.
+
+```yaml
+parameters:
+  - title: Choose a GCP project
+    properties:
+      gcpProject:
+        title: GCP Project
+        type: string
+        ui:field: GcpResourcePicker
+        ui:options:
+          resourceType: project
+          outputFormat: id
+```
+
+`ui:options` supported on this field:
+
+- `resourceType`: `project` (default) or `folder`.
+- `outputFormat`: `id` (default, e.g. `my-project-123` / `123456789`) or
+  `resourceName` (canonical name, e.g. `projects/415104041262` /
+  `folders/123456789`).
+- `parent`: restrict a folder search to a parent, e.g. `folders/123` or
+  `organizations/456` (ignored for project searches).
+- `scopes`: override the requested Google OAuth scopes (default is the read-only
+  Cloud Platform scope).
+- `pageSize`: override how many results are requested per search (default 25).
+  If a search matches more than this, the field prompts the user to refine their
+  search rather than silently truncating.
+
+Example picking a folder scoped to a specific parent:
+
+```yaml
+parameters:
+  - title: Choose a GCP folder
+    properties:
+      gcpFolder:
+        title: GCP Folder
+        type: string
+        ui:field: GcpResourcePicker
+        ui:options:
+          resourceType: folder
+          parent: folders/123456789
+          outputFormat: resourceName
+```
+
+### GcpBillingAccountPicker
+
+`ui:field: GcpBillingAccountPicker` renders a picker for Google Cloud Billing
+accounts the signed-in user has access to — the same accounts they'd see listed
+at [console.cloud.google.com/billing](https://console.cloud.google.com/billing)
+— authenticated with the user's own Google OAuth credentials against the Cloud
+Billing API. Unlike `GcpResourcePicker`, the Cloud Billing API has no free-text
+search endpoint, so this field loads the user's list of billing accounts once
+(following pagination, up to a **2,000 account cap** — 20 pages of 100) and
+filters client-side as they type.
+
+The closed field shows the **billing account ID**; hovering over it shows the
+**account name** as a tooltip. The open dropdown lists both the account name and
+ID for every option, similar to the "Account name" / "ID" columns in the Cloud
+Billing console.
+
+Since the whole account list has to be fetched before it can be searched, the
+field shows a spinner in the input while that initial fetch is in flight
+(and "Loading billing accounts…" if opened before it finishes).
+
+```yaml
+parameters:
+  - title: Choose a billing account
+    properties:
+      billingAccount:
+        title: Billing Account
+        type: string
+        ui:field: GcpBillingAccountPicker
+```
+
+`ui:options` supported on this field:
+
+- `outputFormat`: `id` (default, e.g. `013939-8DE5F0-6BF33F`) or `resourceName`
+  (canonical name, e.g. `billingAccounts/013939-8DE5F0-6BF33F`). Note the field
+  always _displays_ the short ID regardless of this setting — `outputFormat`
+  only changes the value written to the template.
+- `openOnly`: when `true`, excludes closed/disabled billing accounts from the
+  list. Defaults to `false`.
+- `parent`: restrict the list to the sub-accounts of a parent billing account,
+  e.g. `billingAccounts/013939-8DE5F0-6BF33F`. Omit to list top-level accounts.
+- `scopes`: override the requested Google OAuth scopes (default is the read-only
+  Cloud Billing scope).
+
+Because `billingAccounts.list` has no free-text filter, the field fetches every
+account up front rather than paging lazily as you search — but only up to
+**2,000 accounts** (20 pages of 100). If a user can see more than that, the
+field raises an error rather than silently showing a truncated list (and a real
+account could look like it's "missing" from the picker). If you hit this, use
+`parent` to scope the list to a specific billing account's sub-accounts instead
+of listing everything the user can see.
+
+Example restricting to open sub-accounts of a parent, writing the full resource
+name:
+
+```yaml
+parameters:
+  - title: Choose a billing sub-account
+    properties:
+      billingAccount:
+        title: Billing Account
+        type: string
+        ui:field: GcpBillingAccountPicker
+        ui:options:
+          parent: billingAccounts/013939-8DE5F0-6BF33F
+          openOnly: true
+          outputFormat: resourceName
+```


### PR DESCRIPTION
This will allow us to use this field in a scaffolder template later

